### PR TITLE
Full transfer of qc criteria docs into config

### DIFF
--- a/config/real_config.yaml
+++ b/config/real_config.yaml
@@ -1,13 +1,15 @@
 
-hiseq2500_v4:
+default_handlers:
+    - name: UndeterminedPercentageHandler
+      warning: unknown
+      error: 10
+    - name: PoolingEvennessHandler
+      error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
+      warning: unknown
+
+hiseq2500_highouput_v4:
   50-70:
     handlers:
-      - name: UndeterminedPercentageHandler
-        warning: unknown
-        error: 10
-      - name: PoolingEvennessHandler
-        error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
-        warning: unknown
       - name: ClusterPassFilterHandler
         error: 180
         warning: unknown
@@ -19,12 +21,6 @@ hiseq2500_v4:
         error: 1.5
   100-110:
     handlers:
-      - name: UndeterminedPercentageHandler
-        warning: unknown
-        error: 10
-      - name: PoolingEvennessHandler
-        error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
-        warning: unknown
       - name: ClusterPassFilterHandler
         error: 180
         warning: unknown
@@ -36,12 +32,6 @@ hiseq2500_v4:
         error: 2
   120-130:
     handlers:
-      - name: UndeterminedPercentageHandler
-        warning: unknown
-        error: 10
-      - name: PoolingEvennessHandler
-        error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
-        warning: unknown
       - name: ClusterPassFilterHandler
         error: 180
         warning: unknown
@@ -51,3 +41,121 @@ hiseq2500_v4:
       - name: ErrorRateHAndler
         warning: unknown
         error: 2
+
+hiseq2500_rapid_v2:
+  50-70:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 110
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 4.4 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 1.5
+  100-125:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 110
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 8.8 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 2
+  150-175:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 110
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 12.3 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 3
+  250-265:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 110
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 20 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 5
+
+hiseqX_v2:
+  150:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 350
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 39 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 5
+
+miseq_v2:
+  25-50:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 10
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 0.2 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 1
+  150:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 10
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 1.1 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 2
+  250:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 10
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 1.8 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 5
+
+miseq_v3:
+  75:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 18
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 1.1 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 1.5
+  300:
+    handlers:
+      - name: ClusterPassFilterHandler
+        error: 18
+        warning: unknown
+      - name: Q30YieldHander
+        warning: unknown # Give lowest nbr in Gbp
+        error: 3.7 # Give lowest nbr in Gbp
+      - name: ErrorRateHAndler
+        warning: unknown
+        error: 5

--- a/config/real_config.yaml
+++ b/config/real_config.yaml
@@ -4,15 +4,15 @@ default_handlers:
       warning: unknown
       error: 10
     - name: PoolingEvennessHandler
-      error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
       warning: unknown
+      error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
 
 hiseq2500_highouput_v4:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 180
         warning: unknown
+        error: 180
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 7 # Give lowest nbr in Gbp
@@ -22,8 +22,8 @@ hiseq2500_highouput_v4:
   100-110:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 180
         warning: unknown
+        error: 180
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 14 # Give lowest nbr in Gbp
@@ -33,8 +33,8 @@ hiseq2500_highouput_v4:
   120-130:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 180
         warning: unknown
+        error: 180
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 18 # Give lowest nbr in Gbp
@@ -46,8 +46,8 @@ hiseq2500_rapid_v2:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 110
         warning: unknown
+        error: 110
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 4.4 # Give lowest nbr in Gbp
@@ -57,8 +57,8 @@ hiseq2500_rapid_v2:
   100-125:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 110
         warning: unknown
+        error: 110
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 8.8 # Give lowest nbr in Gbp
@@ -68,8 +68,8 @@ hiseq2500_rapid_v2:
   150-175:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 110
         warning: unknown
+        error: 110
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 12.3 # Give lowest nbr in Gbp
@@ -79,8 +79,8 @@ hiseq2500_rapid_v2:
   250-265:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 110
         warning: unknown
+        error: 110
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 20 # Give lowest nbr in Gbp
@@ -92,8 +92,8 @@ hiseqX_v2:
   150:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 350
         warning: unknown
+        error: 350
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 39 # Give lowest nbr in Gbp
@@ -105,8 +105,8 @@ miseq_v2:
   25-50:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 10
         warning: unknown
+        error: 10
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 0.2 # Give lowest nbr in Gbp
@@ -116,8 +116,8 @@ miseq_v2:
   150:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 10
         warning: unknown
+        error: 10
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 1.1 # Give lowest nbr in Gbp
@@ -127,8 +127,8 @@ miseq_v2:
   250:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 10
         warning: unknown
+        error: 10
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 1.8 # Give lowest nbr in Gbp
@@ -140,8 +140,8 @@ miseq_v3:
   75:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 18
         warning: unknown
+        error: 18
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 1.1 # Give lowest nbr in Gbp
@@ -151,8 +151,8 @@ miseq_v3:
   300:
     handlers:
       - name: ClusterPassFilterHandler
-        error: 18
         warning: unknown
+        error: 18
       - name: Q30YieldHander
         warning: unknown # Give lowest nbr in Gbp
         error: 3.7 # Give lowest nbr in Gbp


### PR DESCRIPTION
I've transferred the QC criteria docs into the config. One thing which we need to discuss is how to interpret the intervals in those documents. Are they inclusive at both ends or not? I would assume that's how they are to be interpreted, and that those which have only a single value will always be at that exact value? This is something that we need some extra code to parse later on.