### PR TITLE
Sorting error/warning logs from by the lane id

### DIFF
--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -7,6 +7,14 @@ from checkQC.qc_engine import QCEngine
 from checkQC.config import ConfigFactory
 from checkQC.run_type_recognizer import RunTypeRecognizer
 
+import logging
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(levelname)s %(message)s')
+
+console_log_handler = logging.StreamHandler()
+logging.getLogger("").addHandler(console_log_handler)
+
 
 @click.command("checkqc")
 @click.option("--config_file", help="Path to the checkQC configuration file", type=click.Path())

--- a/checkQC/config.py
+++ b/checkQC/config.py
@@ -1,7 +1,10 @@
 
 from pkg_resources import Requirement, resource_filename
+import logging
 
 import yaml
+
+log = logging.getLogger("")
 
 
 class ConfigFactory(object):
@@ -16,12 +19,12 @@ class ConfigFactory(object):
         try:
             if not config_path:
                 config_path = resource_filename(Requirement.parse('checkQC'), 'checkQC/default_config/config.yaml')
-                print("No config file specified, using default config from {}.".format(config_path))
+                log.info("No config file specified, using default config from {}.".format(config_path))
 
             with open(config_path) as stream:
                 return yaml.load(stream)
         except FileNotFoundError as e:
-            print("Could not find config file: {}".format(e))
+            log.error("Could not find config file: {}".format(e))
             raise e
 
 
@@ -54,10 +57,10 @@ class Config(object):
             handler_config = self._get_matching_handler(instrument_and_reagent_type, read_length)
             return handler_config
         except KeyError as e:
-            print("Could not find a config entry for instrument '{}' "
-                  "with read length '{}'. Please check the provided config "
-                  "file ".format(instrument_and_reagent_type,
-                                 read_length))
+            log.error("Could not find a config entry for instrument '{}' "
+                      "with read length '{}'. Please check the provided config "
+                      "file ".format(instrument_and_reagent_type,
+                                     read_length))
             raise e
 
     def __getitem__(self, item):

--- a/checkQC/handlers/cluster_pf_handler.py
+++ b/checkQC/handlers/cluster_pf_handler.py
@@ -25,8 +25,10 @@ class ClusterPFHandler(QCHandler):
             lane_pf = lane_dict["TotalClustersPF"]
 
             if self.error() != self.UNKNOWN and lane_pf <= float(self.error())*pow(10, 6):
-                yield QCErrorFatal("Clusters PF was to low on lane {}, it was: {}".format(lane_nbr, lane_pf))
+                yield QCErrorFatal("Clusters PF was to low on lane {}, it was: {}".format(lane_nbr, lane_pf),
+                                   ordering=int(lane_nbr))
             elif self.warning() != self.UNKNOWN and lane_pf <= float(self.warning())*pow(10, 6):
-                yield QCErrorWarning("Cluster PF was to low on lane {}, it was: {}".format(lane_nbr, lane_pf))
+                yield QCErrorWarning("Cluster PF was to low on lane {}, it was: {}".format(lane_nbr, lane_pf),
+                                     ordering=int(lane_nbr))
             else:
                 continue

--- a/checkQC/handlers/qc_handler.py
+++ b/checkQC/handlers/qc_handler.py
@@ -1,4 +1,7 @@
 
+import logging
+
+log = logging.getLogger()
 
 class Subscriber(object):
 
@@ -19,32 +22,30 @@ class Subscriber(object):
 
 
 class QCErrorFatal(object):
-    def __init__(self, msg):
+    def __init__(self, msg, ordering=1):
         self.message = msg
+        self.ordering = ordering
 
     def __str__(self):
-        return "Fatal error: {}".format(self.message)
+        return "Fatal QC error: {}".format(self.message)
 
     def __repr__(self):
         return self.__str__()
 
 
 class QCErrorWarning(object):
-    def __init__(self, msg):
+    def __init__(self, msg, ordering=1):
         self.message = msg
+        self.ordering = ordering
 
     def __str__(self):
-        return "Warning: {}".format(self.message)
+        return "QC warning: {}".format(self.message)
 
     def __repr__(self):
         return self.__str__()
 
 
 class QCHandler(Subscriber):
-
-    handlers = []
-    parsers = set()
-    runfolder = None
 
     UNKNOWN = 'unknown'
     ERROR = 'error'
@@ -75,10 +76,12 @@ class QCHandler(Subscriber):
 
     def report(self):
         errors_and_warnings = self.check_qc()
+        sorted_errors_and_warnings = sorted(errors_and_warnings, key=lambda x: x.ordering)
 
-        for element in errors_and_warnings:
+        for element in sorted_errors_and_warnings:
             if isinstance(element, QCErrorFatal):
                 self._exit_status = 1
-            # TODO Switch to proper logging!
-            print(element)
+                log.error(element)
+            else:
+                log.warning(element)
 

--- a/checkQC/handlers/undetermined_percentage_handler.py
+++ b/checkQC/handlers/undetermined_percentage_handler.py
@@ -29,10 +29,12 @@ class UndeterminedPercentageHandler(QCHandler):
 
             if self.error() != self.UNKNOWN and percentage_undetermined > self.error():
                 yield QCErrorFatal("The percentage of undetermined indexes was"
-                                   " to high on lane {}, it was: {}".format(lane_nbr, percentage_undetermined))
+                                   " to high on lane {}, it was: {}".format(lane_nbr, percentage_undetermined),
+                                   ordering=int(lane_nbr))
             elif self.warning() != self.UNKNOWN and percentage_undetermined > self.warning():
                 yield QCErrorWarning("The percentage of undetermined indexes was "
-                                     "to high on lane {}, it was: {}".format(lane_nbr, percentage_undetermined))
+                                     "to high on lane {}, it was: {}".format(lane_nbr, percentage_undetermined),
+                                     ordering=int(lane_nbr))
             else:
                 continue
 

--- a/checkQC/handlers/yield_handler.py
+++ b/checkQC/handlers/yield_handler.py
@@ -26,9 +26,11 @@ class YieldHandler(QCHandler):
             lane_yield = lane_dict["Yield"]
 
             if self.error() != self.UNKNOWN and lane_yield < float(self.error()) * pow(10, 9):
-                yield QCErrorFatal("Yield was to low on lane {}, it was: {}".format(lane_nbr, lane_yield))
+                yield QCErrorFatal("Yield was to low on lane {}, it was: {}".format(lane_nbr, lane_yield),
+                                   ordering=int(lane_nbr))
             elif self.warning() != self.UNKNOWN and lane_yield < float(self.warning()) * pow(10, 9):
-                yield QCErrorWarning("Yield was to low on lane {}, it was: {}".format(lane_nbr, lane_yield))
+                yield QCErrorWarning("Yield was to low on lane {}, it was: {}".format(lane_nbr, lane_yield),
+                                     ordering=int(lane_nbr))
             else:
                 continue
 

--- a/tests/handlers/test_qc_handler.py
+++ b/tests/handlers/test_qc_handler.py
@@ -1,0 +1,35 @@
+import unittest
+
+from checkQC.handlers.qc_handler import QCHandler, QCErrorWarning, QCErrorFatal
+
+
+class TestQCHandler(unittest.TestCase):
+
+    random_qc_errors_and_warning = [QCErrorFatal("1", 1), QCErrorWarning("2", 2),
+                                    QCErrorWarning("3", 3), QCErrorFatal("4", 4)]
+
+    class MockQCHandler(QCHandler):
+        # This is a method to mock returning results from the handler
+        def check_qc(self):
+            return TestQCHandler.random_qc_errors_and_warning
+
+    def setUp(self):
+        qc_config = {}
+        self.qc_handler = self.MockQCHandler(qc_config)
+
+    def test_report_logging_is_ordered(self):
+        def fix_names(obj):
+            if isinstance(obj, QCErrorFatal):
+                return "ERROR:root:{}".format(obj)
+            else:
+                return "WARNING:root:{}".format(obj)
+
+        expected_logs = list(map(fix_names, TestQCHandler.random_qc_errors_and_warning))
+
+        with self.assertLogs() as log_checker:
+            self.qc_handler.report()
+
+        self.assertEqual(log_checker.output, expected_logs)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/handlers/test_qc_handler.py
+++ b/tests/handlers/test_qc_handler.py
@@ -1,3 +1,4 @@
+
 import unittest
 
 from checkQC.handlers.qc_handler import QCHandler, QCErrorWarning, QCErrorFatal
@@ -5,13 +6,17 @@ from checkQC.handlers.qc_handler import QCHandler, QCErrorWarning, QCErrorFatal
 
 class TestQCHandler(unittest.TestCase):
 
-    random_qc_errors_and_warning = [QCErrorFatal("1", 1), QCErrorWarning("2", 2),
-                                    QCErrorWarning("3", 3), QCErrorFatal("4", 4)]
+    expected_qc_errors_and_warning = [QCErrorFatal("1", 1), QCErrorWarning("2", 2),
+                                      QCErrorWarning("3", 3), QCErrorFatal("4", 4)]
+
+    random_order_qc_errors_and_warning = [QCErrorWarning("2", 2), QCErrorFatal("1", 1),
+                                          QCErrorFatal("4", 4), QCErrorWarning("3", 3)]
+
 
     class MockQCHandler(QCHandler):
         # This is a method to mock returning results from the handler
         def check_qc(self):
-            return TestQCHandler.random_qc_errors_and_warning
+            return TestQCHandler.random_order_qc_errors_and_warning
 
     def setUp(self):
         qc_config = {}
@@ -24,7 +29,7 @@ class TestQCHandler(unittest.TestCase):
             else:
                 return "WARNING:root:{}".format(obj)
 
-        expected_logs = list(map(fix_names, TestQCHandler.random_qc_errors_and_warning))
+        expected_logs = list(map(fix_names, TestQCHandler.expected_qc_errors_and_warning))
 
         with self.assertLogs() as log_checker:
             self.qc_handler.report()


### PR DESCRIPTION
This should make sure that within each handler errors/warnings are emitted in a order specified by the user, for our case I'm guessing this will tend to be the lane order.

I have switched to using proper logging, instead of using if statements, to allow this to be tested more easily, which should also make it easier for us to use this code in a library at a later date if we would like to do so.