### PR TITLE
Reading default config and have instrument specific pickup of reagent version

### DIFF
--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -44,15 +44,11 @@ class App(object):
     def run(self):
         config = ConfigFactory.from_config_path(self._config_file)
         run_type_recognizer = RunTypeRecognizer(config=config, runfolder=self._runfolder)
-        instrument_type = run_type_recognizer.instrument_type()
-        reagent_version = run_type_recognizer.reagent_version()
+        instrument_and_reagent_version = run_type_recognizer.instrument_and_reagent_version()
 
         # TODO For now assume symmetric read lengths
         read_length = int(run_type_recognizer.read_length().split("-")[0])
-
-        instrument_and_reagent_type = "_".join([instrument_type, reagent_version])
-
-        handler_config = config.get_handler_config(instrument_and_reagent_type, read_length)
+        handler_config = config.get_handler_config(instrument_and_reagent_version, read_length)
         qc_engine = QCEngine(runfolder=self._runfolder, handler_config=handler_config)
         qc_engine.run()
         self.exit_status = qc_engine.exit_status

--- a/checkQC/config.py
+++ b/checkQC/config.py
@@ -47,6 +47,16 @@ class Config(object):
                     return self._config[instrument_and_reagent_type][int(config_read_length)]["handlers"]
         raise KeyError
 
+    def _add_default_config(self, current_handler_config):
+
+        current_handler_names = set(map(lambda x: x["name"], current_handler_config))
+        default_handlers = self._config["default_handlers"]
+        for default_handler in default_handlers:
+            if not default_handler["name"] in current_handler_names:
+                current_handler_config.append(default_handler)
+        return current_handler_config
+
+
     def get_handler_config(self, instrument_and_reagent_type, read_length):
         """
         :param instrument_and_reagent_type: type of instrument and reagents to match from config
@@ -55,7 +65,8 @@ class Config(object):
         """
         try:
             handler_config = self._get_matching_handler(instrument_and_reagent_type, read_length)
-            return handler_config
+            handler_config_with_defaults = self._add_default_config(handler_config)
+            return handler_config_with_defaults
         except KeyError as e:
             log.error("Could not find a config entry for instrument '{}' "
                       "with read length '{}'. Please check the provided config "

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -7,6 +7,10 @@ instrument_type_mappings:
   D: hiseq2500
   ST: hiseqx
 
+default_handlers:
+    - name: UndeterminedPercentageHandler
+      warning: unknown
+      error: 10
 
 miseq_v3:
   300:

--- a/checkQC/default_config/real_config.yaml
+++ b/checkQC/default_config/real_config.yaml
@@ -1,4 +1,13 @@
 
+# First letter in instrument name is indicative of model
+# i.e. SN7001335 is a HiSeq3500 since its name begins with
+# SN
+instrument_type_mappings:
+  SN: hiseq2000
+  M: miseq
+  D: hiseq2500
+  ST: hiseqx
+
 # Please note that intervals for read lengths are specified as: min < x <= max (i.e. upper inclusive, lower exclusive)
 
 default_handlers:
@@ -90,7 +99,7 @@ hiseq2500_rapid_v2:
         warning: unknown
         error: 5
 
-hiseqX_v2:
+hiseqx_v2:
   150:
     handlers:
       - name: ClusterPassFilterHandler

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -12,6 +12,78 @@ class RunModeUnknown(Exception):
     pass
 
 
+class ReagentVersionUnknown(Exception):
+    pass
+
+
+class IlluminaInstrument(object):
+
+    @staticmethod
+    def get_subclasses():
+        return IlluminaInstrument.__subclasses__()
+
+    @staticmethod
+    def create_instrument_instance(instrument_name):
+        subclasses = IlluminaInstrument.get_subclasses()
+        for subclass in subclasses:
+            if instrument_name == subclass.name():
+                return subclass()
+
+
+class HiSeqX(IlluminaInstrument):
+
+    @staticmethod
+    def name():
+        return "hiseqx"
+
+    @staticmethod
+    def reagent_version(runtype_recognizer):
+        return "v2"
+
+
+class MiSeq(IlluminaInstrument):
+
+    @staticmethod
+    def name():
+        return "miseq"
+
+    @staticmethod
+    def reagent_version(runtype_recognizer):
+        """
+        Find the reagent version used for this run
+        :return: reagent version of format v[number] e.g. v3
+        """
+        try:
+            reagent_version = runtype_recognizer.run_parameters["RunParameters"]["ReagentKitVersion"]
+            return reagent_version.replace("Version", "v")
+        except KeyError:
+            raise ReagentVersionUnknown("No reagent version specified for this instrument type")
+
+
+class HiSeq2500(IlluminaInstrument):
+
+    @staticmethod
+    def name():
+        return "hiseq2500"
+
+    @staticmethod
+    def reagent_version(runtype_recognizer):
+        # TODO This is where to figure out if this is a rapid, reagent version etc...
+        raise NotImplementedError()
+
+
+class HiSeq2000(IlluminaInstrument):
+
+    @staticmethod
+    def name():
+        return "hiseq2000"
+
+    @staticmethod
+    def reagent_version(runtype_recognizer):
+        # TODO This is where to figure out if this is a rapid, reagent version etc...
+        raise NotImplementedError()
+
+
 class RunTypeRecognizer(object):
     """
     RunTypeRecognizer will read files in the runfolder to determine information about the run,
@@ -27,10 +99,10 @@ class RunTypeRecognizer(object):
         self._config = config
         self._runfolder = runfolder
         with open(os.path.join(self._runfolder, "RunInfo.xml")) as f:
-            self._run_info = xmltodict.parse(f.read())
+            self.run_info = xmltodict.parse(f.read())
 
         with open(self._find_run_parameters_xml()) as f:
-            self._run_parameters = xmltodict.parse(f.read())
+            self.run_parameters = xmltodict.parse(f.read())
 
     def _find_run_parameters_xml(self):
         first_option = os.path.join(self._runfolder, "RunParameters.xml")
@@ -42,15 +114,6 @@ class RunTypeRecognizer(object):
         else:
             raise FileNotFoundError("Could not find [R|r]unParameters.xml for runfolder {}".format(self._runfolder))
 
-    def reagent_version(self):
-        """
-        Find the reagent version used for this run
-        :return: reagent version of format v[number] e.g. v3
-        """
-        reagent_version = self._run_parameters["RunParameters"]["ReagentKitVersion"]
-        return reagent_version.replace("Version", "v")
-
-
     def instrument_type(self):
         """
         This will look in the RunInfo.xml and determine the run type, based on the
@@ -58,21 +121,25 @@ class RunTypeRecognizer(object):
         :raises: InstrumentTypeUnknown
         :return: the instrument type of the runfolder
         """
-        instrument_name = self._run_info["RunInfo"]["Run"]["Instrument"]
+        instrument_name = self.run_info["RunInfo"]["Run"]["Instrument"]
         machine_type_mappings = self._config["instrument_type_mappings"]
 
         for key, value in machine_type_mappings.items():
             if instrument_name.startswith(key):
-                return value
+                return IlluminaInstrument.create_instrument_instance(value)
 
         raise InstrumentTypeUnknown("Did not recognize instrument type of: {}".format(instrument_name))
+
+    def instrument_and_reagent_version(self):
+        instrument_type = self.instrument_type()
+        return "_".join([instrument_type.name(), instrument_type.reagent_version(self)])
 
     def read_length(self):
         """
         Gathers information on the read length of the run.
         :return: The read length. If multiple reads delimited by "-"
         """
-        reads = self._run_info["RunInfo"]["Run"]["Reads"]["Read"]
+        reads = self.run_info["RunInfo"]["Run"]["Reads"]["Read"]
 
         read_lengths = []
         for read in reads:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,24 +7,29 @@ from checkQC.config import Config
 class TestConfig(unittest.TestCase):
 
     def setUp(self):
-        self.first_handler = {"first_handler"}
-        self.second_handler = {"second_handler"}
+        self.first_handler = {"name": "first_handler"}
+        self.second_handler = {"name": "second_handler"}
+        self.default_handler = {"name": "default_handler", "config": "some_value"}
         config_dict = {'instrument_type_mappings': {'SN': 'hiseq2000', 'M': 'miseq', 'D': 'hiseq2500', 'ST': 'hiseqx'},
                        'miseq_v3': {
                            300: {'handlers': [
                                self.first_handler]},
                            '150-299': {'handlers': [
                                self.second_handler]}
-                       }}
+                       },
+                       "default_handlers": [
+                           self.default_handler,
+                           self.first_handler
+                       ]}
         self.config = Config(config_dict)
 
     def test_exact_match(self):
         handlers = self.config.get_handler_config('miseq_v3', 300)
-        self.assertListEqual(handlers, [self.first_handler])
+        self.assertListEqual(handlers, [self.first_handler, self.default_handler])
 
     def test_interval_match(self):
         handlers = self.config.get_handler_config('miseq_v3', 175)
-        self.assertListEqual(handlers, [self.second_handler])
+        self.assertListEqual(handlers, [self.second_handler, self.default_handler, self.first_handler])
 
     def test_no_match(self):
         with self.assertRaises(KeyError):
@@ -32,7 +37,7 @@ class TestConfig(unittest.TestCase):
 
     def test_call_with_str(self):
         handlers = self.config.get_handler_config('miseq_v3', "300")
-        self.assertListEqual(handlers, [self.first_handler])
+        self.assertListEqual(handlers, [self.first_handler, self.default_handler])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -17,14 +17,10 @@ class TestRunTypeRecognizer(TestCase):
     def test_instrument_type(self):
         expected = "miseq"
         actual = self.runtype_recognizer.instrument_type()
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, actual.name())
 
     def test_read_length(self):
         expected = "300-300"
         actual = self.runtype_recognizer.read_length()
         self.assertEqual(expected, actual)
 
-    def test_find_reagent_version(self):
-        expected = "v3"
-        actual = self.runtype_recognizer.reagent_version()
-        self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR does to things:

1) It ensures that the default handlers are loaded, unless a handler with the same name has already been defined for that instrument.
2) It allows getting the reagent version to be specified on a per instrument type level. This means that to introduce new instruments one needs to actually add code, which is not optimal, but I think that for now this is the most pragmatic way of solving the problem.

@monikaBrandt Check the `TODO` tags for where to place the code to check if a run is rapid/highoutput.