### PR TITLE
Separate rapid from non rapid

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Please return once we have a release. :D
 to be modular, and exactly which "qc handlers" are executed with which parameters for a specific run type (i.e. machine
 type and run length) is determined by a configuration file.
 
+Instrument types supported in checkQC are the following:
+ - HiSeqX
+ - HiSeq2500
+ - MiSeq
+
 Install instructions
 --------------------
 

--- a/checkQC/default_config/real_config.yaml
+++ b/checkQC/default_config/real_config.yaml
@@ -3,7 +3,6 @@
 # i.e. SN7001335 is a HiSeq3500 since its name begins with
 # SN
 instrument_type_mappings:
-  SN: hiseq2000
   M: miseq
   D: hiseq2500
   ST: hiseqx
@@ -12,161 +11,161 @@ instrument_type_mappings:
 
 default_handlers:
     - name: UndeterminedPercentageHandler
-      warning: unknown
-      error: 10
+      warning: 10
+      error: 30
     - name: PoolingEvennessHandler
-      warning: unknown
-      error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
+      warning: 50
+      error: unknown # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
 
 hiseq2500_rapidhighoutput_v4:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 180
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 7 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 1.5
+        warning: 180
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 7 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 1.5
+        error: unknown
   100-110:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 180
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 14 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 2
+        warning: 180
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 14 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 2
+        error: unknown
   120-130:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 180
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 18 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 2
+        warning: 180
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 18 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 2
+        error: unknown
 
 hiseq2500_rapidrun_v2:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 110
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 4.4 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 1.5
+        warning: 110
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 4.4 # Give lowest nbr in Gbp
+        error: uknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 1.5
+        error: unknown
   100-125:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 110
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 8.8 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 2
+        warning: 110
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 8.8 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 2
+        error: unknown
   150-175:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 110
-      - name: Q30YieldHander
+        warning: 110
+        error: unknown
+      - name: Q30YieldHandler
         warning: unknown # Give lowest nbr in Gbp
         error: 12.3 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
+      - name: ErrorRateHandler
         warning: unknown
         error: 3
   250-265:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 110
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 20 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 5
+        warning: 110
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 20 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 5
+        error: unknown
 
 hiseqx_v2:
   150:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 350
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 39 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 5
+        warning: 400
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 39 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 5
+        error: unknown
 
 miseq_v2:
   25-50:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 10
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 0.2 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 1
+        warning: 10
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 0.2 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 1
+        error: unknown
   150:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 10
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 1.1 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 2
+        warning: 10
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 1.1 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 2
+        error: uknown
   250:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 10
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 1.8 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 5
+        warning: 10
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 1.8 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 5
+        error: unknown
 
 miseq_v3:
   75:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 18
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 1.1 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 1.5
+        warning: 18
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 1.1 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 1.5
+        error: unknown
   300:
     handlers:
       - name: ClusterPassFilterHandler
-        warning: unknown
-        error: 18
-      - name: Q30YieldHander
-        warning: unknown # Give lowest nbr in Gbp
-        error: 3.7 # Give lowest nbr in Gbp
-      - name: ErrorRateHAndler
-        warning: unknown
-        error: 5
+        warning: 18
+        error: unknown
+      - name: Q30YieldHandler
+        warning: 3.7 # Give lowest nbr in Gbp
+        error: unknown # Give lowest nbr in Gbp
+      - name: ErrorRateHandler
+        warning: 5
+        error: unknown

--- a/checkQC/default_config/real_config.yaml
+++ b/checkQC/default_config/real_config.yaml
@@ -18,7 +18,7 @@ default_handlers:
       warning: unknown
       error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
 
-hiseq2500_rapidhighouput_v4:
+hiseq2500_rapidhighoutput_v4:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler

--- a/checkQC/default_config/real_config.yaml
+++ b/checkQC/default_config/real_config.yaml
@@ -18,7 +18,7 @@ default_handlers:
       warning: unknown
       error: 50 # Each sample should have  >= x % of the clusters divded by the number of samples in the pool
 
-hiseq2500_highouput_v4:
+hiseq2500_rapidhighouput_v4:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler
@@ -53,7 +53,7 @@ hiseq2500_highouput_v4:
         warning: unknown
         error: 2
 
-hiseq2500_rapid_v2:
+hiseq2500_rapidrun_v2:
   50-70:
     handlers:
       - name: ClusterPassFilterHandler

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -68,7 +68,11 @@ class HiSeq2500(IlluminaInstrument):
 
     @staticmethod
     def reagent_version(runtype_recognizer):
-        # TODO This is where to figure out if this is a rapid, reagent version etc...
+        """
+        Find run mode (rapid or not) and reagent version used for this run
+        :return run mode (as specified in RunInfo.xml) and reagent version
+        joint as one string
+        """
         try:
             run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"]
         except KeyError:
@@ -90,7 +94,11 @@ class HiSeq2000(IlluminaInstrument):
 
     @staticmethod
     def reagent_version(runtype_recognizer):
-        # TODO This is where to figure out if this is a rapid, reagent version etc...
+        """
+        Find run mode (rapid or not) and reagent version used for this run
+        :return run mode (as specified in RunInfo.xml) and reagent version
+        joint as one string
+        """
         try:
             run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"]
         except KeyError:

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -71,45 +71,21 @@ class HiSeq2500(IlluminaInstrument):
         """
         Find run mode (rapid or not) and reagent version used for this run
         :return run mode (as specified in RunInfo.xml) and reagent version
-        joint as one string
+        joint as one string e.g. rapidhighoutput_v4 or rapidrun_v2
         """
         try:
-            run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"]
+            run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"].lower()
         except KeyError:
             raise RunModeUnknown("No run mode specified for this instrument type")
 
         try:
             reagent_version = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["Sbs"]
+            #Select last element from string "HiSeq SBS Kit v4"
+            format_reagent_version= reagent_version.split(" ")[-1].strip().lower()
         except KeyError:
             raise ReagentVersionUnknown("No reagent version specified for this instrument type and run mode")
 
-        return run_mode.lower()+"_"+reagent_version.split(" ")[-1].strip()
-
-
-class HiSeq2000(IlluminaInstrument):
-
-    @staticmethod
-    def name():
-        return "hiseq2000"
-
-    @staticmethod
-    def reagent_version(runtype_recognizer):
-        """
-        Find run mode (rapid or not) and reagent version used for this run
-        :return run mode (as specified in RunInfo.xml) and reagent version
-        joint as one string
-        """
-        try:
-            run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"]
-        except KeyError:
-            raise RunModeUnknown("No run mode specified for this instrument type")
-
-        try:
-            reagent_version = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["Sbs"]
-        except KeyError:
-            raise ReagentVersionUnknown("No reagent version specified for this instrument type and run mode")
-
-        return run_mode.lower()+"_"+reagent_version.split(" ")[-1].strip()
+        return "{}_{}".format(run_mode, format_reagent_version)
 
 
 class RunTypeRecognizer(object):

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -69,7 +69,17 @@ class HiSeq2500(IlluminaInstrument):
     @staticmethod
     def reagent_version(runtype_recognizer):
         # TODO This is where to figure out if this is a rapid, reagent version etc...
-        raise NotImplementedError()
+        try:
+            run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"]
+        except KeyError:
+            raise RunModeUnknown("No run mode specified for this instrument type")
+
+        try:
+            reagent_version = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["Sbs"]
+        except KeyError:
+            raise ReagentVersionUnknown("No reagent version specified for this instrument type and run mode")
+
+        return run_mode.lower()+"_"+reagent_version.split(" ")[-1].strip()
 
 
 class HiSeq2000(IlluminaInstrument):
@@ -81,7 +91,17 @@ class HiSeq2000(IlluminaInstrument):
     @staticmethod
     def reagent_version(runtype_recognizer):
         # TODO This is where to figure out if this is a rapid, reagent version etc...
-        raise NotImplementedError()
+        try:
+            run_mode = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["RunMode"]
+        except KeyError:
+            raise RunModeUnknown("No run mode specified for this instrument type")
+
+        try:
+            reagent_version = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["Sbs"]
+        except KeyError:
+            raise ReagentVersionUnknown("No reagent version specified for this instrument type and run mode")
+
+        return run_mode.lower()+"_"+reagent_version.split(" ")[-1].strip()
 
 
 class RunTypeRecognizer(object):

--- a/tests/resources/HighOut/RunInfo.xml
+++ b/tests/resources/HighOut/RunInfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="2">
+  <Run Id="170726_D00118_0303_BCB1TVANXX" Number="303">
+    <Flowcell>CB1TVANXX</Flowcell>
+    <Instrument>D00118</Instrument>
+    <Date>170726</Date>
+    <Reads>
+      <Read Number="1" NumCycles="126" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="4" NumCycles="126" IsIndexedRead="N" />
+    </Reads>
+    <FlowcellLayout LaneCount="8" SurfaceCount="2" SwathCount="3" TileCount="16" />
+    <AlignToPhiX>
+      <Lane>1</Lane>
+      <Lane>2</Lane>
+      <Lane>3</Lane>
+      <Lane>4</Lane>
+      <Lane>5</Lane>
+      <Lane>6</Lane>
+      <Lane>7</Lane>
+      <Lane>8</Lane>
+    </AlignToPhiX>
+  </Run>
+</RunInfo>

--- a/tests/resources/HighOut/runParameters.xml
+++ b/tests/resources/HighOut/runParameters.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0"?>
+<RunParameters xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Setup>
+    <ExperimentName>170726</ExperimentName>
+    <ScanID>-999</ScanID>
+    <FCPosition>B</FCPosition>
+    <WorkFlowType>DUALINDEX</WorkFlowType>
+    <PairEndFC>true</PairEndFC>
+    <Read1>126</Read1>
+    <IndexRead1>8</IndexRead1>
+    <IndexRead2>8</IndexRead2>
+    <Read2>126</Read2>
+    <OutputFolder>L:\runfolders</OutputFolder>
+    <CompressBcls>true</CompressBcls>
+    <RemapQScores />
+    <PeriodicSave>Save All Thumbnails</PeriodicSave>
+    <Flowcell>HiSeq Flow Cell v4</Flowcell>
+    <FirstBaseConfirmation>true</FirstBaseConfirmation>
+    <SampleSheet />
+    <KeepIntensityFiles>false</KeepIntensityFiles>
+    <Sbs>HiSeq SBS Kit v4</Sbs>
+    <Pe>HiSeq PE Cluster Kit v4 - cBot - HS</Pe>
+    <Index>HiSeq v4 Dual Index</Index>
+    <AlignToPhiX>
+      <Lane>1</Lane>
+      <Lane>2</Lane>
+      <Lane>3</Lane>
+      <Lane>4</Lane>
+      <Lane>5</Lane>
+      <Lane>6</Lane>
+      <Lane>7</Lane>
+      <Lane>8</Lane>
+    </AlignToPhiX>
+    <ClusteringChoice>None</ClusteringChoice>
+    <RapidRunChemistry>None</RapidRunChemistry>
+    <RunMode>RapidHighOutput</RunMode>
+    <Rehyb>None</Rehyb>
+    <PerformPreRunFluidicsCheck>false</PerformPreRunFluidicsCheck>
+    <ServiceRun>false</ServiceRun>
+    <ApplicationName>HiSeq Control Software</ApplicationName>
+    <ApplicationVersion>2.2.58</ApplicationVersion>
+    <RunID>170726_D00118_0303_BCB1TVANXX</RunID>
+    <RunStartDate>170726</RunStartDate>
+    <IntegrationMode>Standalone</IntegrationMode>
+    <BaseSpaceSettings>
+      <RunMonitoringOnly>false</RunMonitoringOnly>
+      <Username />
+      <PlannedRun>false</PlannedRun>
+      <RunId />
+      <TempFolder />
+      <SendInstrumentHealthToILMN>false</SendInstrumentHealthToILMN>
+    </BaseSpaceSettings>
+    <ScannerID>D00118</ScannerID>
+    <ScanNumber>303</ScanNumber>
+    <ComputerName>HISEQ</ComputerName>
+    <FPGAVersion>7.9.7</FPGAVersion>
+    <CPLDVersion>3.0.0</CPLDVersion>
+    <RTAVersion>1.18.64</RTAVersion>
+    <ChemistryVersion>Illumina,Bruno Fluidics Controller,0,v2.0340</ChemistryVersion>
+    <CameraFirmware>2.01-F20-R01</CameraFirmware>
+    <CameraDriver>6.45.20.3689</CameraDriver>
+    <FocusCameraFirmware />
+    <Barcode>CB1TVANXX</Barcode>
+    <WashBarcode>CWASHACXX</WashBarcode>
+    <Username>sbsuser</Username>
+    <SelectedSections>
+      <Section Name="A_1" />
+      <Section Name="B_1" />
+      <Section Name="C_1" />
+      <Section Name="D_1" />
+      <Section Name="E_1" />
+      <Section Name="F_1" />
+      <Section Name="G_1" />
+      <Section Name="H_1" />
+    </SelectedSections>
+    <FocusMethod>DynamicITF</FocusMethod>
+    <SelectedSurface>BothLaneSurfaces</SelectedSurface>
+    <SwathScanMode>AutoSwath</SwathScanMode>
+    <EnableLft>true</EnableLft>
+    <AutoTiltOnce>true</AutoTiltOnce>
+    <EnableAutoCenter>true</EnableAutoCenter>
+    <EnableAnalysis>true</EnableAnalysis>
+    <EnableBasecalling>true</EnableBasecalling>
+    <EnableCameraLogging>false</EnableCameraLogging>
+    <AdapterPlate>HiSeq Adapter Plate</AdapterPlate>
+    <SlideHolder>HiSeq Flow Cell Holder</SlideHolder>
+    <TemplateCycleCount>5</TemplateCycleCount>
+    <NumAnalysisThreads>8</NumAnalysisThreads>
+    <FPGADynamicFocusSettings>
+      <MaxInitialZJumpHalfUm>3</MaxInitialZJumpHalfUm>
+      <MaxSubsequentZJumpHalfUm>7</MaxSubsequentZJumpHalfUm>
+      <NumberOfInitialZJumps>0</NumberOfInitialZJumps>
+      <CVGainStart>500</CVGainStart>
+      <CVGainPosLocked>500</CVGainPosLocked>
+      <Offset>250</Offset>
+      <HotPixel>350</HotPixel>
+      <MotorDelayFrames>10</MotorDelayFrames>
+      <SoftwareLaserLag>200</SoftwareLaserLag>
+      <DitherSize>100</DitherSize>
+      <GroupSize>40</GroupSize>
+      <DitherShift>0</DitherShift>
+      <IntensityCeiling>65535</IntensityCeiling>
+      <IGain>100</IGain>
+      <IHistory>4</IHistory>
+    </FPGADynamicFocusSettings>
+    <TileWidth>2048</TileWidth>
+    <TileHeight>10000</TileHeight>
+    <ImageWidth>2048</ImageWidth>
+    <ImageHeight>160000</ImageHeight>
+    <AreaPerPixelmm2>1.40625E-07</AreaPerPixelmm2>
+    <LaneLength>60</LaneLength>
+    <NumTilesPerSwath>16</NumTilesPerSwath>
+    <NumSwaths>3</NumSwaths>
+    <UseExistingRecipe>false</UseExistingRecipe>
+    <Reads>
+      <Read Number="1" NumCycles="126" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="3" NumCycles="8" IsIndexedRead="Y" />
+      <Read Number="4" NumCycles="126" IsIndexedRead="N" />
+    </Reads>
+    <EnableNotifications>false</EnableNotifications>
+    <ReagentKits>
+      <Sbs>
+        <SbsReagentKit>
+          <ID>170726</ID>
+          <Prime>false</Prime>
+          <NumberCyclesRemaining>275</NumberCyclesRemaining>
+          <IsNew50Cycle>false</IsNew50Cycle>
+          <IsNew200Cycle>true</IsNew200Cycle>
+          <IsNew500Cycle>false</IsNew500Cycle>
+        </SbsReagentKit>
+      </Sbs>
+      <Index>
+        <ReagentKit>
+          <ID />
+        </ReagentKit>
+      </Index>
+      <Pe>
+        <ReagentKit>
+          <ID>170726</ID>
+        </ReagentKit>
+      </Pe>
+      <Rehyb />
+    </ReagentKits>
+    <ReagentBottles>
+      <Sbs />
+    </ReagentBottles>
+    <Resume>false</Resume>
+    <ResumeCycle>0</ResumeCycle>
+    <SupportMultipleSurfacesInUI>true</SupportMultipleSurfacesInUI>
+    <TempFolder>E:\Illumina\HiSeqTemp\170726_D00118_0303_BCB1TVANXX</TempFolder>
+    <RecipeFragmentVersion>1.5.21.0</RecipeFragmentVersion>
+    <PromptForPeReagents>false</PromptForPeReagents>
+    <MockRun>false</MockRun>
+    <ScannedBarcode />
+  </Setup>
+  <Version>1</Version>
+</RunParameters>

--- a/tests/resources/Rapid/RunInfo.xml
+++ b/tests/resources/Rapid/RunInfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<RunInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="2">
+  <Run Id="170920_D00118_0309_BHVLWWBCXY" Number="309">
+    <Flowcell>HVLWWBCXY</Flowcell>
+    <Instrument>D00118</Instrument>
+    <Date>170920</Date>
+    <Reads>
+      <Read Number="1" NumCycles="51" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="7" IsIndexedRead="Y" />
+    </Reads>
+    <FlowcellLayout LaneCount="2" SurfaceCount="2" SwathCount="2" TileCount="16" />
+    <AlignToPhiX>
+      <Lane>1</Lane>
+      <Lane>2</Lane>
+    </AlignToPhiX>
+  </Run>
+</RunInfo>

--- a/tests/resources/Rapid/runParameters.xml
+++ b/tests/resources/Rapid/runParameters.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<RunParameters xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Setup>
+    <ExperimentName>170920</ExperimentName>
+    <ScanID>-999</ScanID>
+    <FCPosition>B</FCPosition>
+    <WorkFlowType>SINGLEINDEX</WorkFlowType>
+    <PairEndFC>false</PairEndFC>
+    <Read1>51</Read1>
+    <IndexRead1>7</IndexRead1>
+    <IndexRead2>0</IndexRead2>
+    <Read2>0</Read2>
+    <OutputFolder>L:\runfolders</OutputFolder>
+    <CompressBcls>true</CompressBcls>
+    <RemapQScores />
+    <PeriodicSave>Save All Thumbnails</PeriodicSave>
+    <Flowcell>HiSeq Rapid Flow Cell v2</Flowcell>
+    <FirstBaseConfirmation>true</FirstBaseConfirmation>
+    <SampleSheet>Z:\Instrument\HVLWWBCXY_samplesheet.csv</SampleSheet>
+    <KeepIntensityFiles>false</KeepIntensityFiles>
+    <Sbs>HiSeq Rapid SBS Kit v2</Sbs>
+    <Pe />
+    <Index>HiSeq Rapid SR Cluster Kit v2</Index>
+    <AlignToPhiX>
+      <Lane>1</Lane>
+      <Lane>2</Lane>
+    </AlignToPhiX>
+    <ClusteringChoice>OnBoardClustering</ClusteringChoice>
+    <RapidRunChemistry>RapidRunV2</RapidRunChemistry>
+    <RunMode>RapidRun</RunMode>
+    <Rehyb>None</Rehyb>
+    <PerformPreRunFluidicsCheck>false</PerformPreRunFluidicsCheck>
+    <ServiceRun>false</ServiceRun>
+    <ApplicationName>HiSeq Control Software</ApplicationName>
+    <ApplicationVersion>2.2.58</ApplicationVersion>
+    <RunID>170920_D00118_0309_BHVLWWBCXY</RunID>
+    <RunStartDate>170920</RunStartDate>
+    <IntegrationMode>Standalone</IntegrationMode>
+    <BaseSpaceSettings>
+      <RunMonitoringOnly>false</RunMonitoringOnly>
+      <Username />
+      <PlannedRun>false</PlannedRun>
+      <RunId />
+      <TempFolder />
+      <SendInstrumentHealthToILMN>false</SendInstrumentHealthToILMN>
+    </BaseSpaceSettings>
+    <ScannerID>D00118</ScannerID>
+    <ScanNumber>309</ScanNumber>
+    <ComputerName>HISEQ</ComputerName>
+    <FPGAVersion>7.9.7</FPGAVersion>
+    <CPLDVersion>3.0.0</CPLDVersion>
+    <RTAVersion>1.18.64</RTAVersion>
+    <ChemistryVersion>Illumina,Bruno Fluidics Controller,0,v2.0340</ChemistryVersion>
+    <CameraFirmware>2.01-F20-R01</CameraFirmware>
+    <CameraDriver>6.45.20.3689</CameraDriver>
+    <FocusCameraFirmware />
+    <Barcode>HVLWWBCXY</Barcode>
+    <Username>sbsuser</Username>
+    <SelectedSections>
+      <Section Name="A_1" />
+      <Section Name="B_1" />
+    </SelectedSections>
+    <FocusMethod>DynamicITF</FocusMethod>
+    <SelectedSurface>BothLaneSurfaces</SelectedSurface>
+    <SwathScanMode>DualSwathFC</SwathScanMode>
+    <EnableLft>true</EnableLft>
+    <AutoTiltOnce>true</AutoTiltOnce>
+    <EnableAutoCenter>true</EnableAutoCenter>
+    <EnableAnalysis>true</EnableAnalysis>
+    <EnableBasecalling>true</EnableBasecalling>
+    <EnableCameraLogging>false</EnableCameraLogging>
+    <AdapterPlate>HiSeq Adapter Plate</AdapterPlate>
+    <SlideHolder>HiSeq Flow Cell Holder</SlideHolder>
+    <TemplateCycleCount>5</TemplateCycleCount>
+    <NumAnalysisThreads>8</NumAnalysisThreads>
+    <FPGADynamicFocusSettings>
+      <MaxInitialZJumpHalfUm>3</MaxInitialZJumpHalfUm>
+      <MaxSubsequentZJumpHalfUm>7</MaxSubsequentZJumpHalfUm>
+      <NumberOfInitialZJumps>0</NumberOfInitialZJumps>
+      <CVGainStart>500</CVGainStart>
+      <CVGainPosLocked>500</CVGainPosLocked>
+      <Offset>250</Offset>
+      <HotPixel>350</HotPixel>
+      <MotorDelayFrames>10</MotorDelayFrames>
+      <SoftwareLaserLag>200</SoftwareLaserLag>
+      <DitherSize>100</DitherSize>
+      <GroupSize>50</GroupSize>
+      <DitherShift>0</DitherShift>
+      <IntensityCeiling>65535</IntensityCeiling>
+      <IGain>100</IGain>
+      <IHistory>4</IHistory>
+    </FPGADynamicFocusSettings>
+    <TileWidth>2048</TileWidth>
+    <TileHeight>10000</TileHeight>
+    <ImageWidth>2048</ImageWidth>
+    <ImageHeight>160000</ImageHeight>
+    <AreaPerPixelmm2>1.40625E-07</AreaPerPixelmm2>
+    <LaneLength>60</LaneLength>
+    <NumTilesPerSwath>16</NumTilesPerSwath>
+    <NumSwaths>2</NumSwaths>
+    <UseExistingRecipe>false</UseExistingRecipe>
+    <Reads>
+      <Read Number="1" NumCycles="51" IsIndexedRead="N" />
+      <Read Number="2" NumCycles="7" IsIndexedRead="Y" />
+    </Reads>
+    <EnableNotifications>false</EnableNotifications>
+    <ReagentKits>
+      <Sbs>
+        <SbsReagentKit>
+          <ID>170920</ID>
+          <Prime>false</Prime>
+          <NumberCyclesRemaining>74</NumberCyclesRemaining>
+          <IsNew50Cycle>true</IsNew50Cycle>
+          <IsNew200Cycle>false</IsNew200Cycle>
+          <IsNew500Cycle>false</IsNew500Cycle>
+        </SbsReagentKit>
+      </Sbs>
+      <Index>
+        <ReagentKit>
+          <ID>170920</ID>
+        </ReagentKit>
+      </Index>
+      <Pe />
+      <Rehyb />
+    </ReagentKits>
+    <ReagentBottles>
+      <Sbs />
+    </ReagentBottles>
+    <Resume>false</Resume>
+    <ResumeCycle>0</ResumeCycle>
+    <SupportMultipleSurfacesInUI>true</SupportMultipleSurfacesInUI>
+    <TempFolder>E:\Illumina\HiSeqTemp\170920_D00118_0309_BHVLWWBCXY</TempFolder>
+    <RecipeFragmentVersion>1.5.21.0</RecipeFragmentVersion>
+    <PromptForPeReagents>false</PromptForPeReagents>
+    <MockRun>false</MockRun>
+    <ScannedBarcode />
+  </Setup>
+  <Version>1</Version>
+</RunParameters>

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -6,21 +6,24 @@ from checkQC.run_type_recognizer import RunTypeRecognizer
 
 class TestRunTypeRecognizer(TestCase):
 
-    CONFIG = {"instrument_type_mappings":
-                  {"M": "miseq"}}
+    CONFIG = {"instrument_type_mappings":{"M": "miseq","D": "hiseq2500","SN": "hiseq2000"}}
 
     def setUp(self):
         self.runtype_recognizer = RunTypeRecognizer(runfolder=os.path.join(os.path.dirname(__file__),
-                                                                           "resources", "MiSeqDemo"),
+                                                                           "resources", "Rapid"),
                                                     config=self.CONFIG)
 
     def test_instrument_type(self):
-        expected = "miseq"
+        expected = "hiseq2500"
         actual = self.runtype_recognizer.instrument_type()
         self.assertEqual(expected, actual.name())
 
     def test_read_length(self):
-        expected = "300-300"
+        expected = "50"
         actual = self.runtype_recognizer.read_length()
         self.assertEqual(expected, actual)
 
+    def test_run_mode(self):
+        expected = "hiseq2500_rapidrun_v2"
+        actual = self.runtype_recognizer.instrument_and_reagent_version()
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR will enable the possibility to separate rapid-runs from non-rapid-runs given the RunInfo.xml and runInfoParameters.xml from a HiSeq2500-run.