### PR TITLE
Validate configurations and give error on missing error rate

### DIFF
--- a/checkQC/config.py
+++ b/checkQC/config.py
@@ -7,6 +7,10 @@ import yaml
 log = logging.getLogger("")
 
 
+class ConfigurationError(Exception):
+    pass
+
+
 class ConfigFactory(object):
 
     @staticmethod
@@ -55,7 +59,6 @@ class Config(object):
             if not default_handler["name"] in current_handler_names:
                 current_handler_config.append(default_handler)
         return current_handler_config
-
 
     def get_handler_config(self, instrument_and_reagent_type, read_length):
         """

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -33,6 +33,7 @@ hiseq2500_rapidhighoutput_v4:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 1.5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -47,6 +48,7 @@ hiseq2500_rapidhighoutput_v4:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 2
         error: unknown
       - name: ReadsPerSampleHandler
@@ -61,6 +63,7 @@ hiseq2500_rapidhighoutput_v4:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 2
         error: unknown
       - name: ReadsPerSampleHandler
@@ -77,6 +80,7 @@ hiseq2500_rapidrun_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 1.5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -91,6 +95,7 @@ hiseq2500_rapidrun_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 2
         error: unknown
       - name: ReadsPerSampleHandler
@@ -105,6 +110,7 @@ hiseq2500_rapidrun_v2:
         warning: unknown # Give percentage for reads greater than Q30
         error: 12.3 # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: unknown
         error: 80
       - name: ReadsPerSampleHandler
@@ -119,6 +125,7 @@ hiseq2500_rapidrun_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -135,6 +142,7 @@ hiseqx_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -153,6 +161,7 @@ novaseq_v1:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -169,6 +178,7 @@ miseq_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 1
         error: unknown
       - name: ReadsPerSampleHandler
@@ -183,6 +193,7 @@ miseq_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 2
         error: uknown
       - name: ReadsPerSampleHandler
@@ -197,6 +208,7 @@ miseq_v2:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -213,6 +225,7 @@ miseq_v3:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 1.5
         error: unknown
       - name: ReadsPerSampleHandler
@@ -227,6 +240,7 @@ miseq_v3:
         warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
+        allow_missing_error_rate: False
         warning: 5
         error: unknown
       - name: ReadsPerSampleHandler

--- a/checkQC/handlers/error_rate_handler.py
+++ b/checkQC/handlers/error_rate_handler.py
@@ -1,9 +1,12 @@
 
 from checkQC.handlers.qc_handler import QCHandler, QCErrorFatal, QCErrorWarning
 from checkQC.parsers.interop_parser import InteropParser
+from checkQC.config import ConfigurationError
 
 
 class ErrorRateHandler(QCHandler):
+
+    ALLOW_MISSING_ERROR_RATE = "allow_missing_error_rate"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -17,6 +20,16 @@ class ErrorRateHandler(QCHandler):
         if key == "error_rate":
             self.error_results.append(value)
 
+    def custom_configuration_validation(self):
+        try:
+            value = self.qc_config[self.ALLOW_MISSING_ERROR_RATE]
+        except KeyError as e:
+            raise ConfigurationError("Did not find key '{}' in configuration for ErrorRate handler".format(e.args[0]))
+
+        if not isinstance(value, bool):
+            raise ConfigurationError("Only True/False are allowed as values for 'allow_missing_error_rate' in the "
+                                     "ErrorRate handler config. Value was: {}".format(value))
+
     def check_qc(self):
 
         for error_dict in self.error_results:
@@ -24,7 +37,12 @@ class ErrorRateHandler(QCHandler):
             read = error_dict["read"]
             error_rate = error_dict["error_rate"]
 
-            if self.error() != self.UNKNOWN and error_rate > self.error():
+            if error_rate == 0 and not self.qc_config[self.ALLOW_MISSING_ERROR_RATE]:
+                yield QCErrorFatal("Error rate was found to be 0 on lane: {} for read: {}, this is probably "
+                                   "because there was no PhiX loaded on this lane. If do not use PhiX for your "
+                                   "runs you can set 'allow_missing_error_rate' in the config to True, which will "
+                                   "remove the messages in the future.".format(lane_nbr, read))
+            elif self.error() != self.UNKNOWN and error_rate > self.error():
                 yield QCErrorFatal("Error rate {} was to high on lane: {} for read: {}".format(error_rate,
                                                                                                lane_nbr,
                                                                                                read),

--- a/checkQC/handlers/qc_handler.py
+++ b/checkQC/handlers/qc_handler.py
@@ -1,7 +1,10 @@
 
 import logging
 
+from checkQC.config import ConfigurationError
+
 log = logging.getLogger()
+
 
 class Subscriber(object):
 
@@ -56,6 +59,21 @@ class QCHandler(Subscriber):
         self._exit_status = 0
         self.qc_config = qc_config
 
+    def custom_configuration_validation(self):
+        """
+        Override this method in subclass to provide additional configuration behaviour.
+        Raise a `ConfigurationError` if there is a problem with the provided config.
+        """
+        pass
+
+    def validate_configuration(self):
+        try:
+            self.qc_config[self.ERROR]
+            self.qc_config[self.WARNING]
+        except KeyError as e:
+            raise ConfigurationError("Configuration expects key: {}. Perhaps it is missing?".format(e.args[0]))
+        self.custom_configuration_validation()
+
     def error(self):
         return self.qc_config[self.ERROR]
 
@@ -66,7 +84,7 @@ class QCHandler(Subscriber):
         return self._exit_status
 
     def parser(self):
-        raise NotImplementedError("A parser needs to return the class of the parser it needs!")
+        raise NotImplementedError("A handler needs to return the class of the parser it needs!")
 
     def collect(self, value):
         raise NotImplementedError

--- a/tests/handlers/test_error_rate_handler.py
+++ b/tests/handlers/test_error_rate_handler.py
@@ -44,5 +44,36 @@ class TestErrorRateHandler(HandlerTestBase):
         class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
         self.assertListEqual(class_names, ['QCErrorFatal', 'QCErrorFatal'])
 
+    def test_error_rate_zero_not_allowed(self):
+        key = "error_rate"
+        value_1 = {"lane": 1, "read": 1, "error_rate": 0}
+        value_2 = {"lane": 1, "read": 2, "error_rate": 0}
+        # Empty the default list, and then add some more values
+        self.error_handler.error_results = []
+        self.error_handler.collect((key, value_1))
+        self.error_handler.collect((key, value_2))
+
+        qc_config = {'name': 'ErrorHandler', 'error': 2.9, 'warning': 1, 'allow_missing_error_rate': False}
+        self.set_qc_config(qc_config)
+        errors_and_warnings = list(self.error_handler.check_qc())
+        self.assertEqual(len(errors_and_warnings), 2)
+
+        class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
+        self.assertListEqual(class_names, ['QCErrorFatal', 'QCErrorFatal'])
+
+    def test_error_rate_zero_is_allowed(self):
+        key = "error_rate"
+        value_1 = {"lane": 1, "read": 1, "error_rate": 0}
+        value_2 = {"lane": 1, "read": 2, "error_rate": 0}
+        # Empty the default list, and then add some more values
+        self.error_handler.error_results = []
+        self.error_handler.collect((key, value_1))
+        self.error_handler.collect((key, value_2))
+
+        qc_config = {'name': 'ErrorHandler', 'error': 2.9, 'warning': 1, 'allow_missing_error_rate': True}
+        self.set_qc_config(qc_config)
+        errors_and_warnings = list(self.error_handler.check_qc())
+        self.assertEqual(len(errors_and_warnings), 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/handlers/test_qc_handler.py
+++ b/tests/handlers/test_qc_handler.py
@@ -2,6 +2,7 @@
 import unittest
 
 from checkQC.handlers.qc_handler import QCHandler, QCErrorWarning, QCErrorFatal
+from checkQC.config import ConfigurationError
 
 
 class TestQCHandler(unittest.TestCase):
@@ -35,6 +36,11 @@ class TestQCHandler(unittest.TestCase):
             self.qc_handler.report()
 
         self.assertEqual(log_checker.output, expected_logs)
+
+    def test_validate_configuration(self):
+        mock_handler = self.MockQCHandler({})
+        with self.assertRaises(ConfigurationError):
+            mock_handler.validate_configuration()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This introduces two thing:
 - The possibility for handlers to validate their own configuration prior to running. By default they will check that they have a `warning` and `error` field, but by implementing the `custom_configuration_validation` method any type of config can be checked.
 - When the error rate is zero, it is likely that it means that no PhiX was added to that lane. The default will be to throw an error and exit with a non-zero exit status if this happens, but it can be configured by setting the `allow_missing_error_rate` to `True` in the config.