### PR TITLE
Adding json mode

### DIFF
--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -18,7 +18,7 @@ log = logging.getLogger("")
 
 @click.command("checkqc")
 @click.option("--config", help="Path to the checkQC configuration file", type=click.Path())
-@click.option('--json', is_flag=True, default=False)
+@click.option('--json', is_flag=True, default=False, help="Print the results of the run as json to stdout")
 @click.argument('runfolder', type=click.Path())
 def start(config, json, runfolder):
     """

--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -22,7 +22,7 @@ log = logging.getLogger("")
 @click.argument('runfolder', type=click.Path())
 def start(config, json, runfolder):
     """
-    checkQC is a command line utility designed to quickly gather and assess quality control metrics from a
+    checkQC is a command line utility designed to quickly gather and assess quality control metrics from an
     Illumina sequencing run. It is highly customizable and which quality controls modules should be run
     for a particular run type should be specified in the provided configuration file.
     """

--- a/checkQC/handlers/cluster_pf_handler.py
+++ b/checkQC/handlers/cluster_pf_handler.py
@@ -28,11 +28,11 @@ class ClusterPFHandler(QCHandler):
                 yield QCErrorFatal("Clusters PF was to low on lane {}, "
                                    "it was: {:.2f} M".format(lane_nbr, lane_pf/pow(10, 6)),
                                    ordering=lane_nbr,
-                                   data={'lane': lane_nbr, 'lane_pf': lane_pf, 'threshold': self.warning()})
+                                   data={'lane': lane_nbr, 'lane_pf': lane_pf, 'threshold': self.error()})
             elif self.warning() != self.UNKNOWN and lane_pf < float(self.warning())*pow(10, 6):
                 yield QCErrorWarning("Cluster PF was to low on lane {}, "
                                      "it was: {:.2f} M".format(lane_nbr, lane_pf/pow(10, 6)),
                                      ordering=lane_nbr,
-                                     data={'lane': lane_nbr, 'lane_pf': lane_pf, 'threshold': self.error()})
+                                     data={'lane': lane_nbr, 'lane_pf': lane_pf, 'threshold': self.warning()})
             else:
                 continue

--- a/checkQC/handlers/cluster_pf_handler.py
+++ b/checkQC/handlers/cluster_pf_handler.py
@@ -21,16 +21,18 @@ class ClusterPFHandler(QCHandler):
     def check_qc(self):
 
         for lane_dict in self.conversion_results:
-            lane_nbr = lane_dict["LaneNumber"]
+            lane_nbr = int(lane_dict["LaneNumber"])
             lane_pf = lane_dict["TotalClustersPF"]
 
             if self.error() != self.UNKNOWN and lane_pf < float(self.error())*pow(10, 6):
                 yield QCErrorFatal("Clusters PF was to low on lane {}, "
                                    "it was: {:.2f} M".format(lane_nbr, lane_pf/pow(10, 6)),
-                                   ordering=int(lane_nbr))
+                                   ordering=lane_nbr,
+                                   data={'lane': lane_nbr, 'lane_pf': lane_pf, 'threshold': self.warning()})
             elif self.warning() != self.UNKNOWN and lane_pf < float(self.warning())*pow(10, 6):
                 yield QCErrorWarning("Cluster PF was to low on lane {}, "
                                      "it was: {:.2f} M".format(lane_nbr, lane_pf/pow(10, 6)),
-                                     ordering=int(lane_nbr))
+                                     ordering=lane_nbr,
+                                     data={'lane': lane_nbr, 'lane_pf': lane_pf, 'threshold': self.error()})
             else:
                 continue

--- a/checkQC/handlers/error_rate_handler.py
+++ b/checkQC/handlers/error_rate_handler.py
@@ -33,7 +33,7 @@ class ErrorRateHandler(QCHandler):
     def check_qc(self):
 
         for error_dict in self.error_results:
-            lane_nbr = error_dict["lane"]
+            lane_nbr = int(error_dict["lane"])
             read = error_dict["read"]
             error_rate = error_dict["error_rate"]
 
@@ -46,12 +46,16 @@ class ErrorRateHandler(QCHandler):
                 yield QCErrorFatal("Error rate {} was to high on lane: {} for read: {}".format(error_rate,
                                                                                                lane_nbr,
                                                                                                read),
-                                   ordering=int(lane_nbr))
+                                   ordering=lane_nbr,
+                                   data={"lane": lane_nbr, "read": read,
+                                         "error_rate": error_rate, "threshold": self.error()})
             elif self.warning() != self.UNKNOWN and error_rate > self.warning():
                 yield QCErrorWarning("Error rate {} was to high on lane: {} for read: {}".format(error_rate,
                                                                                                  lane_nbr,
                                                                                                  error_rate),
-                                     ordering=int(lane_nbr))
+                                     ordering=lane_nbr,
+                                     data={"lane": lane_nbr, "read": read,
+                                           "error_rate": error_rate, "threshold": self.warning()})
             else:
                 continue
 

--- a/checkQC/handlers/q30_handler.py
+++ b/checkQC/handlers/q30_handler.py
@@ -20,7 +20,7 @@ class Q30Handler(QCHandler):
     def check_qc(self):
 
         for error_dict in self.error_results:
-            lane_nbr = error_dict["lane"]
+            lane_nbr = int(error_dict["lane"])
             read = error_dict["read"]
             percent_q30 = error_dict["percent_q30"]
 
@@ -28,12 +28,16 @@ class Q30Handler(QCHandler):
                 yield QCErrorFatal("%Q30 {:.2f} was too low on lane: {} for read: {}".format(percent_q30,
                                                                                              lane_nbr,
                                                                                              read),
-                                   ordering=int(lane_nbr))
+                                   ordering=lane_nbr,
+                                   data={"lane": lane_nbr, "read": read,
+                                         "percent_q30": percent_q30, "threshold": self.error()})
             elif self.warning() != self.UNKNOWN and percent_q30 < self.warning():
                 yield QCErrorWarning("%Q30 {:.2f} was too low on lane: {} for read: {}".format(percent_q30,
                                                                                                lane_nbr,
                                                                                                read),
-                                     ordering=int(lane_nbr))
+                                     ordering=lane_nbr,
+                                     data={"lane": lane_nbr, "read": read,
+                                           "percent_q30": percent_q30, "threshold": self.warning()})
             else:
                 continue
 

--- a/checkQC/handlers/qc_handler.py
+++ b/checkQC/handlers/qc_handler.py
@@ -1,5 +1,6 @@
 
 import logging
+import json
 
 from checkQC.config import ConfigurationError
 
@@ -25,9 +26,10 @@ class Subscriber(object):
 
 
 class QCErrorFatal(object):
-    def __init__(self, msg, ordering=1):
+    def __init__(self, msg, ordering=1, data=None) :
         self.message = msg
         self.ordering = ordering
+        self.data = data
 
     def __str__(self):
         return "Fatal QC error: {}".format(self.message)
@@ -35,17 +37,24 @@ class QCErrorFatal(object):
     def __repr__(self):
         return self.__str__()
 
+    def as_dict(self):
+        return {'type': 'error', 'message': self.message, 'data': self.data}
+
 
 class QCErrorWarning(object):
-    def __init__(self, msg, ordering=1):
+    def __init__(self, msg, ordering=1, data=None):
         self.message = msg
         self.ordering = ordering
+        self.data = data
 
     def __str__(self):
         return "QC warning: {}".format(self.message)
 
     def __repr__(self):
         return self.__str__()
+
+    def as_dict(self):
+        return {'type': 'warning', 'message': self.message, 'data': self.data}
 
 
 class QCHandler(Subscriber):
@@ -102,4 +111,6 @@ class QCHandler(Subscriber):
                 log.error(element)
             else:
                 log.warning(element)
+
+        return sorted_errors_and_warnings
 

--- a/checkQC/handlers/reads_per_sample_handler.py
+++ b/checkQC/handlers/reads_per_sample_handler.py
@@ -20,7 +20,7 @@ class ReadsPerSampleHandler(QCHandler):
     def check_qc(self):
 
         for lane_dict in self.conversion_results:
-            lane_nbr = lane_dict["LaneNumber"]
+            lane_nbr = int(lane_dict["LaneNumber"])
             lane_demux = lane_dict["DemuxResults"]
             nbr_of_samples = len(lane_demux)
 
@@ -32,11 +32,17 @@ class ReadsPerSampleHandler(QCHandler):
                 if self.error() != self.UNKNOWN and sample_total_reads < (float(self.error()) / float(nbr_of_samples)):
                     yield QCErrorFatal("Number of reads for sample {} was too low on lane {}, "
                                        "it was: {:.3f} M".format(sample_id, lane_nbr, sample_total_reads),
-                                       ordering=int(lane_nbr))
+                                       ordering=lane_nbr,
+                                       data={"lane": lane_nbr, "number_of_samples": nbr_of_samples,
+                                             "sample_id": sample_id, "sample_reads": sample_total_reads,
+                                             "threshold": self.error()})
                 elif self.warning() != self.UNKNOWN and \
                                 sample_total_reads < (float(self.warning()) / float(nbr_of_samples)):
                     yield QCErrorWarning("Number of reads for sample {} was too low on lane {}, "
                                          "it was: {:.3f} M".format(sample_id, lane_nbr, sample_total_reads),
-                                         ordering=int(lane_nbr))
+                                         ordering=lane_nbr,
+                                         data={"lane": lane_nbr, "number_of_samples": nbr_of_samples,
+                                               "sample_id": sample_id, "sample_reads": sample_total_reads,
+                                               "threshold": self.warning()})
                 else:
                     continue

--- a/checkQC/handlers/undetermined_percentage_handler.py
+++ b/checkQC/handlers/undetermined_percentage_handler.py
@@ -23,7 +23,7 @@ class UndeterminedPercentageHandler(QCHandler):
             # If no index was specified for a lane, there will be no undetermined
             # Undetermined key for that lane in the Stats.json file. /JD 2017-10-02
             if lane_dict.get("Undetermined"):
-                lane_nbr = lane_dict["LaneNumber"]
+                lane_nbr = int(lane_dict["LaneNumber"])
                 total_yield = lane_dict["Yield"]
 
                 undetermined_yield = lane_dict["Undetermined"]["Yield"]
@@ -33,11 +33,15 @@ class UndeterminedPercentageHandler(QCHandler):
                 if self.error() != self.UNKNOWN and percentage_undetermined > self.error():
                     yield QCErrorFatal("The percentage of undetermined indexes was"
                                        " to high on lane {}, it was: {:.2f}%".format(lane_nbr, percentage_undetermined),
-                                       ordering=int(lane_nbr))
+                                       ordering=lane_nbr,
+                                       data={"lane": lane_nbr, "percentage_undetermined": percentage_undetermined,
+                                             "threshold": self.error()})
                 elif self.warning() != self.UNKNOWN and percentage_undetermined > self.warning():
                     yield QCErrorWarning("The percentage of undetermined indexes was "
                                          "to high on lane {}, it was: {:.2f}%".format(lane_nbr, percentage_undetermined),
-                                         ordering=int(lane_nbr))
+                                         ordering=lane_nbr,
+                                         data={"lane": lane_nbr, "percentage_undetermined": percentage_undetermined,
+                                               "threshold": self.warning()})
                 else:
                     continue
 

--- a/checkQC/handlers/yield_handler.py
+++ b/checkQC/handlers/yield_handler.py
@@ -22,15 +22,17 @@ class YieldHandler(QCHandler):
     def check_qc(self):
 
         for lane_dict in self.conversion_results:
-            lane_nbr = lane_dict["LaneNumber"]
+            lane_nbr = int(lane_dict["LaneNumber"])
             lane_yield = lane_dict["Yield"]
 
             if self.error() != self.UNKNOWN and lane_yield < float(self.error()) * pow(10, 9):
                 yield QCErrorFatal("Yield was to low on lane {}, it was: {}".format(lane_nbr, lane_yield),
-                                   ordering=int(lane_nbr))
+                                   ordering=lane_nbr,
+                                   data={"lane": lane_nbr, "yield": lane_yield, "threshold": self.error()})
             elif self.warning() != self.UNKNOWN and lane_yield < float(self.warning()) * pow(10, 9):
                 yield QCErrorWarning("Yield was to low on lane {}, it was: {}".format(lane_nbr, lane_yield),
-                                     ordering=int(lane_nbr))
+                                     ordering=lane_nbr,
+                                     data={"lane": lane_nbr, "yield": lane_yield, "threshold": self.warning()})
             else:
                 continue
 

--- a/checkQC/qc_engine.py
+++ b/checkQC/qc_engine.py
@@ -28,7 +28,8 @@ class QCEngine(object):
             self._initiate_parsers()
             self._subscribe_handlers_to_parsers()
             self._run_parsers()
-            self._compile_reports()
+            reports = self._compile_reports()
+            return reports
         except ConfigurationError:
             self.exit_status = 1
 
@@ -61,7 +62,11 @@ class QCEngine(object):
             parser.run()
 
     def _compile_reports(self):
+        reports = {}
         for handler in self._handlers:
-            handler.report()
+            handler_report = handler.report()
+            if handler_report:
+                reports[type(handler).__name__] = list(map(lambda x: x.as_dict(), handler_report))
             if handler.exit_status() != 0:
                 self.exit_status = 1
+        return reports

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,6 +13,11 @@ class TestApp(unittest.TestCase):
     def test_run(self):
         self.app.run()
 
+    def test_run_json_mode(self):
+        app = App(runfolder=os.path.join(os.path.dirname(__file__), "resources", "170726_D00118_0303_BCB1TVANXX/"),
+                  json_mode=True)
+        app.run()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a new mode json mode to CheckQC. When this flag is used it will print the reports as json to stdout. This is useful to pass the results to other programs, and will make it easier to add webservice capabilities to CheckQC in the future.

Here is an example of that this will look like:

```
$ checkqc --json tests/resources/170726_D00118_0303_BCB1TVANXX/ 2> /dev/null | python -m json.tool
{
    "ClusterPFHandler": [
        {
            "type": "warning",
            "message": "Cluster PF was to low on lane 1, it was: 117.93 M",
            "data": {
                "lane": 1,
                "lane_pf": 117929896,
                "threshold": "unknown"
            }
        },
        {
            "type": "warning",
            "message": "Cluster PF was to low on lane 7, it was: 122.26 M",
            "data": {
                "lane": 7,
                "lane_pf": 122263375,
                "threshold": "unknown"
            }
        },
        {
            "type": "warning",
            "message": "Cluster PF was to low on lane 8, it was: 177.02 M",
            "data": {
                "lane": 8,
                "lane_pf": 177018999,
                "threshold": "unknown"
            }
        }
    ],
    "ReadsPerSampleHandler": [
        {
            "type": "warning",
            "message": "Number of reads for sample Sample_pq-27 was too low on lane 7, it was: 6.893 M",
            "data": {
                "lane": 7,
                "number_of_samples": 12,
                "sample_id": "Sample_pq-27",
                "sample_reads": 6.893002,
                "threshold": 90
            }
        },
        {
            "type": "warning",
            "message": "Number of reads for sample Sample_pq-28 was too low on lane 7, it was: 7.104 M",
            "data": {
                "lane": 7,
                "number_of_samples": 12,
                "sample_id": "Sample_pq-28",
                "sample_reads": 7.10447,
                "threshold": 90
            }
        }
    ]
}
```