### PR TITLE
WIP: Initial draft for webservice implementation

### DIFF
--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.DEBUG,
 console_log_handler = logging.StreamHandler()
 log = logging.getLogger("")
 
+
 @click.command("checkqc")
 @click.option("--config", help="Path to the checkQC configuration file", type=click.Path())
 @click.option('--json', is_flag=True, default=False, help="Print the results of the run as json to stdout")
@@ -43,11 +44,7 @@ class App(object):
         self._json_mode = json_mode
         self.exit_status = 0
 
-    def run(self):
-        log.info("----------------")
-        log.info("Starting checkQC")
-        log.info("----------------")
-        log.info("Runfolder is: {}".format(self._runfolder))
+    def configure_and_run(self):
         config = ConfigFactory.from_config_path(self._config_file)
         run_type_recognizer = RunTypeRecognizer(config=config, runfolder=self._runfolder)
         instrument_and_reagent_version = run_type_recognizer.instrument_and_reagent_version()
@@ -58,6 +55,14 @@ class App(object):
         qc_engine = QCEngine(runfolder=self._runfolder, handler_config=handler_config)
         reports = qc_engine.run()
         self.exit_status = qc_engine.exit_status
+        return reports
+
+    def run(self):
+        log.info("----------------")
+        log.info("Starting checkQC")
+        log.info("----------------")
+        log.info("Runfolder is: {}".format(self._runfolder))
+        reports = self.configure_and_run()
         if self.exit_status == 0:
             log.info("Finished without finding any fatal qc errors.")
         else:

--- a/checkQC/config.py
+++ b/checkQC/config.py
@@ -4,7 +4,7 @@ import logging
 
 import yaml
 
-log = logging.getLogger("")
+log = logging.getLogger(__name__)
 
 
 class ConfigurationError(Exception):
@@ -27,6 +27,18 @@ class ConfigFactory(object):
 
             with open(config_path) as stream:
                 return yaml.load(stream)
+        except FileNotFoundError as e:
+            log.error("Could not find config file: {}".format(e))
+            raise e
+
+    @staticmethod
+    def get_logging_config_file(config_path):
+        try:
+            if not config_path:
+                config_path = resource_filename(Requirement.parse('checkQC'), 'checkQC/default_config/logger.yaml')
+                log.info("No logging config file specified, using default config from {}.".format(config_path))
+                with open(config_path) as stream:
+                    return yaml.load(stream)
         except FileNotFoundError as e:
             log.error("Could not find config file: {}".format(e))
             raise e

--- a/checkQC/config.py
+++ b/checkQC/config.py
@@ -32,13 +32,13 @@ class ConfigFactory(object):
             raise e
 
     @staticmethod
-    def get_logging_config_file(config_path):
+    def get_logging_config_dict(config_path):
         try:
             if not config_path:
                 config_path = resource_filename(Requirement.parse('checkQC'), 'checkQC/default_config/logger.yaml')
                 log.info("No logging config file specified, using default config from {}.".format(config_path))
-                with open(config_path) as stream:
-                    return yaml.load(stream)
+            with open(config_path) as stream:
+                return yaml.load(stream)
         except FileNotFoundError as e:
             log.error("Could not find config file: {}".format(e))
             raise e

--- a/checkQC/default_config/logger.yaml
+++ b/checkQC/default_config/logger.yaml
@@ -1,0 +1,28 @@
+---
+version: 1
+
+disable_existing_loggers: False
+
+formatters:
+    simple:
+        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+
+    file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: DEBUG
+        formatter: simple
+        filename: checkqc-ws.log
+        maxBytes: 10485760  # 10MB
+        backupCount: 20
+        encoding: utf8
+
+root:
+    level: DEBUG
+    handlers: [console, file_handler]

--- a/checkQC/qc_engine.py
+++ b/checkQC/qc_engine.py
@@ -62,7 +62,7 @@ class QCEngine(object):
             parser.run()
 
     def _compile_reports(self):
-        reports = {}
+        reports = {"exit_status": 0}
         for handler in self._handlers:
             handler_report = handler.report()
             if handler_report:

--- a/checkQC/qc_engine.py
+++ b/checkQC/qc_engine.py
@@ -5,7 +5,7 @@ import logging
 from checkQC.handlers.qc_handler_factory import QCHandlerFactory
 from checkQC.config import ConfigurationError
 
-log = logging.getLogger("")
+log = logging.getLogger(__name__)
 
 
 class QCEngine(object):
@@ -69,4 +69,5 @@ class QCEngine(object):
                 reports[type(handler).__name__] = list(map(lambda x: x.as_dict(), handler_report))
             if handler.exit_status() != 0:
                 self.exit_status = 1
+                reports["exit_status"] = 1
         return reports

--- a/checkQC/web_app.py
+++ b/checkQC/web_app.py
@@ -65,7 +65,7 @@ class WebApp(object):
         return server
 
     def start_web_app(self, monitoring_path, port, config_file, log_config, debug):
-        logging_config_path = ConfigFactory.get_logging_config_file(log_config)
+        logging_config_path = ConfigFactory.get_logging_config_dict(log_config)
         logging.config.dictConfig(logging_config_path)
 
         log.info("Starting checkqc-ws at port: {}".format(port))

--- a/checkQC/web_app.py
+++ b/checkQC/web_app.py
@@ -2,11 +2,13 @@
 import logging
 import logging.config
 import os
+from concurrent.futures import ProcessPoolExecutor
 
 import click
 
 import tornado.ioloop
 import tornado.web
+import tornado.httpserver
 from tornado.gen import coroutine
 from tornado.web import url
 
@@ -18,14 +20,27 @@ log = logging.getLogger(__name__)
 
 class CheckQCHandler(tornado.web.RequestHandler):
 
+    # To make the ProcessPoolExecutor and Tornado play well together, this needs to be
+    # set after the server has been started. This is kind of hacky, but it appears to work
+    # well enough for now. An explanation of the problem is available here:
+    # https://stackoverflow.com/questions/26370139/tornado-concurrency-errors-running-multiple-processes-together-with-a-process-po/26370643#26370643
+    # / JD 2017-11-08
+    process_pool = None
+
     def initialize(self, **kwargs):
         self.monitor_path = kwargs["monitoring_path"]
         self.qc_config_file = kwargs["qc_config_file"]
 
-    def get(self, runfolder):
-        path_to_runfolder = os.path.join(self.monitor_path, runfolder)
-        checkqc_app = App(config_file=self.qc_config_file, runfolder=path_to_runfolder)
+    @staticmethod
+    def _run_check_qc(monitor_path, qc_config_file, runfolder):
+        path_to_runfolder = os.path.join(monitor_path, runfolder)
+        checkqc_app = App(config_file=qc_config_file, runfolder=path_to_runfolder)
         reports = checkqc_app.configure_and_run()
+        return reports
+
+    @coroutine
+    def get(self, runfolder):
+        reports = yield self.process_pool.submit(self._run_check_qc, self.monitor_path, self.qc_config_file, runfolder)
         self.set_header("Content-Type", "application/json")
         self.write(reports)
 
@@ -35,10 +50,19 @@ class WebApp(object):
     def __init__(self):
         pass
 
-    def _make_app(self, debug=False, **kwargs):
-        routes = [url(r"/([^/]+)", CheckQCHandler, name="checkqc", kwargs=kwargs)]
+    @staticmethod
+    def _routes(**kwargs):
+        return [url(r"/qc/([^/]+)", CheckQCHandler, name="checkqc", kwargs=kwargs)]
 
-        return tornado.web.Application(routes, debug=debug)
+    @staticmethod
+    def _make_app(debug=False, **kwargs):
+        return tornado.web.Application(WebApp._routes(kwargs), debug=debug)
+
+    @staticmethod
+    def _create_server(port, app):
+        server = tornado.httpserver.HTTPServer(app)
+        server.bind(port)
+        return server
 
     def start_web_app(self, monitoring_path, port, config_file, log_config, debug):
         logging_config_path = ConfigFactory.get_logging_config_file(log_config)
@@ -46,9 +70,13 @@ class WebApp(object):
 
         log.info("Starting checkqc-ws at port: {}".format(port))
 
+        # See the comment above in the CheckQCHandler as to why this somewhat backward way
+        # is used to setup the server and ProcessPoolExecutor. /JD 2017-11-08
         web_app = self._make_app(monitoring_path=monitoring_path, qc_config_file=config_file, debug=debug)
-        web_app.listen(port)
-        tornado.ioloop.IOLoop.current().start()
+        server = self._create_server(port=port, app=web_app)
+        server.start()
+        CheckQCHandler.process_pool = ProcessPoolExecutor()
+        tornado.ioloop.IOLoop.instance().start()
 
 
 @click.command("checkqc-ws")

--- a/checkQC/web_app.py
+++ b/checkQC/web_app.py
@@ -1,0 +1,62 @@
+
+import logging
+import logging.config
+import os
+
+import click
+
+import tornado.ioloop
+import tornado.web
+from tornado.gen import coroutine
+from tornado.web import url
+
+from checkQC.app import App
+from checkQC.config import ConfigFactory
+
+log = logging.getLogger(__name__)
+
+
+class CheckQCHandler(tornado.web.RequestHandler):
+
+    def initialize(self, **kwargs):
+        self.monitor_path = kwargs["monitoring_path"]
+        self.qc_config_file = kwargs["qc_config_file"]
+
+    def get(self, runfolder):
+        path_to_runfolder = os.path.join(self.monitor_path, runfolder)
+        checkqc_app = App(config_file=self.qc_config_file, runfolder=path_to_runfolder)
+        reports = checkqc_app.configure_and_run()
+        self.set_header("Content-Type", "application/json")
+        self.write(reports)
+
+
+class WebApp(object):
+
+    def __init__(self):
+        pass
+
+    def _make_app(self, debug=False, **kwargs):
+        routes = [url(r"/([^/]+)", CheckQCHandler, name="checkqc", kwargs=kwargs)]
+
+        return tornado.web.Application(routes, debug=debug)
+
+    def start_web_app(self, monitoring_path, port, config_file, log_config, debug):
+        logging_config_path = ConfigFactory.get_logging_config_file(log_config)
+        logging.config.dictConfig(logging_config_path)
+
+        log.info("Starting checkqc-ws at port: {}".format(port))
+
+        web_app = self._make_app(monitoring_path=monitoring_path, qc_config_file=config_file, debug=debug)
+        web_app.listen(port)
+        tornado.ioloop.IOLoop.current().start()
+
+
+@click.command("checkqc-ws")
+@click.argument('monitor_path', type=click.Path())
+@click.option("--port", help="Port which checkqc-ws will listen to (default: 9999).", type=click.INT, default=9999)
+@click.option("--config", help="Path to the checkQC configuration file", type=click.Path())
+@click.option("--log_config", help="Path to the checkQC logging configuration file", type=click.Path())
+@click.option('--debug', is_flag=True, default=False, help="Enable debug mode.")
+def start(monitor_path, port=9999, config=None, log_config=None, debug=False):
+    webapp = WebApp()
+    webapp.start_web_app(monitor_path, port, config, log_config, debug)

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,14 @@ setup(
         "click",
         "PyYAML>=3.12",
         "interop",
-        "xmltodict"],
+        "xmltodict",
+        "tornado"],
     packages=find_packages(),
     package_data={'checkQC': ['default_config/config.yaml']},
     include_package_data=True,
     license='GPLv3',
     entry_points={
-        'console_scripts': ['checkqc = checkQC.app:start']
+        'console_scripts': ['checkqc = checkQC.app:start',
+                            'checkqc-ws = checkQC.web_app:start']
     },
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,15 +7,14 @@ from checkQC.app import App
 
 class TestApp(unittest.TestCase):
 
-    def setUp(self):
-        self.app = App(runfolder=os.path.join(os.path.dirname(__file__), "resources", "170726_D00118_0303_BCB1TVANXX/"))
+    RUNFOLDER = os.path.join(os.path.dirname(__file__), "resources", "170726_D00118_0303_BCB1TVANXX/")
 
     def test_run(self):
-        self.app.run()
+        app = App(runfolder=self.RUNFOLDER)
+        app.run()
 
     def test_run_json_mode(self):
-        app = App(runfolder=os.path.join(os.path.dirname(__file__), "resources", "170726_D00118_0303_BCB1TVANXX/"),
-                  json_mode=True)
+        app = App(runfolder=self.RUNFOLDER, json_mode=True)
         app.run()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from checkQC.config import Config
+from checkQC.config import Config, ConfigFactory
 
 
 class TestConfig(unittest.TestCase):
@@ -38,6 +38,26 @@ class TestConfig(unittest.TestCase):
     def test_call_with_str(self):
         handlers = self.config.get_handler_config('miseq_v3', "300")
         self.assertListEqual(handlers, [self.first_handler, self.default_handler])
+
+class TestConfigFactory(unittest.TestCase):
+
+    def test_get_logging_config_file_default(self):
+        result = ConfigFactory.get_logging_config_dict(None)
+        default_config = {'version': 1, 'disable_existing_loggers': False,
+                          'formatters':
+                              {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
+                          'handlers':
+                              {'console':
+                                   {'class': 'logging.StreamHandler', 'level': 'DEBUG', 'formatter': 'simple',
+                                    'stream': 'ext://sys.stdout'},
+                               'file_handler': {'class': 'logging.handlers.RotatingFileHandler', 'level': 'DEBUG',
+                                                'formatter': 'simple', 'filename': 'checkqc-ws.log',
+                                                'maxBytes': 10485760, 'backupCount': 20,
+                                                'encoding': 'utf8'}},
+                          'root':
+                              {'level': 'DEBUG', 'handlers': ['console', 'file_handler']}}
+        self.assertEqual(result, default_config)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,7 @@ class TestConfig(unittest.TestCase):
         handlers = self.config.get_handler_config('miseq_v3', "300")
         self.assertListEqual(handlers, [self.first_handler, self.default_handler])
 
+
 class TestConfigFactory(unittest.TestCase):
 
     def test_get_logging_config_file_default(self):

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,22 @@
+
+from concurrent.futures import ProcessPoolExecutor
+
+import tornado.web
+from tornado.testing import *
+
+from checkQC.web_app import WebApp, CheckQCHandler
+
+
+class TestWebApp(AsyncHTTPTestCase):
+
+    def get_app(self):
+        routes = WebApp._routes(monitoring_path=os.path.join("tests", "resources"),
+                                qc_config_file=None)
+        CheckQCHandler.process_pool = ProcessPoolExecutor()
+        return tornado.web.Application(routes)
+
+
+    def test_qc_endpoint(self):
+        response = self.fetch('/qc/170726_D00118_0303_BCB1TVANXX')
+        self.assertEqual(response.code, 200)
+


### PR DESCRIPTION
This doesn't have any tests yet, nor is it running asynchronously. I'll fix that next week.

For now this will make it possible to run checkqc as a webservice, and get something like this back:

```
$ curl -w'\n' localhost:9999/170726_D00118_0303_BCB1TVANXX | python -m json.tool
{
    "ClusterPFHandler": [
        {
            "data": {
                "lane": 1,
                "lane_pf": 117929896,
                "threshold": 180
            },
            "message": "Cluster PF was to low on lane 1, it was: 117.93 M",
            "type": "warning"
        },
        {
            "data": {
                "lane": 7,
                "lane_pf": 122263375,
                "threshold": 180
            },
            "message": "Cluster PF was to low on lane 7, it was: 122.26 M",
            "type": "warning"
        },
        {
            "data": {
                "lane": 8,
                "lane_pf": 177018999,
                "threshold": 180
            },
            "message": "Cluster PF was to low on lane 8, it was: 177.02 M",
            "type": "warning"
        }
    ],
    "ReadsPerSampleHandler": [
        {
            "data": {
                "lane": 7,
                "number_of_samples": 12,
                "sample_id": "Sample_pq-27",
                "sample_reads": 6.893002,
                "threshold": 90
            },
            "message": "Number of reads for sample Sample_pq-27 was too low on lane 7, it was: 6.893 M",
            "type": "warning"
        },
        {
            "data": {
                "lane": 7,
                "number_of_samples": 12,
                "sample_id": "Sample_pq-28",
                "sample_reads": 7.10447,
                "threshold": 90
            },
            "message": "Number of reads for sample Sample_pq-28 was too low on lane 7, it was: 7.104 M",
            "type": "warning"
        }
    ],
    "exit_status": 0
}
```
