### PR TITLE
Feature/avoid forking from service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use an official Python runtime as a parent image
+FROM python:3.6-slim
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages specified in requirements.txt and deploy app
+RUN pip install --trusted-host pypi.python.org -r requirements/dev && \
+    python setup.py develop
+
+# Make port 80 available to the world outside this container
+EXPOSE 80
+
+# Start the web service when the container launches
+ENTRYPOINT ["checkqc-ws", "--port=80", "--debug"]
+CMD ["/app/tests/resources"]

--- a/README.md
+++ b/README.md
@@ -285,7 +285,3 @@ $ curl -s -w'\n' localhost:9999/qc/170726_D00118_0303_BCB1TVANXX | python -m jso
     "version": "1.1.0"
 }
 ```
-
-
-
-

--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -77,7 +77,8 @@ class App(object):
             reports["run_summary"] = run_type_summary
             self.exit_status = qc_engine.exit_status
             return reports
-        except CheckQCException:
+        except CheckQCException as e:
+            log.error(e)
             self.exit_status = 1
 
     def run(self):

--- a/checkQC/web_app.py
+++ b/checkQC/web_app.py
@@ -2,14 +2,11 @@
 import logging
 import logging.config
 import os
-from concurrent.futures import ProcessPoolExecutor
 
 import click
 
 import tornado.ioloop
 import tornado.web
-import tornado.httpserver
-from tornado.gen import coroutine
 from tornado.web import url
 
 from checkQC.app import App
@@ -21,12 +18,6 @@ from checkQC import __version__ as checkqc_version
 
 class CheckQCHandler(tornado.web.RequestHandler):
 
-    # To make the ProcessPoolExecutor and Tornado play well together, this needs to be
-    # set after the server has been started. This is kind of hacky, but it appears to work
-    # well enough for now. An explanation of the problem is available here:
-    # https://stackoverflow.com/questions/26370139/tornado-concurrency-errors-running-multiple-processes-together-with-a-process-po/26370643#26370643
-    # / JD 2017-11-08
-    process_pool = None
 
     def initialize(self, **kwargs):
         self.monitor_path = kwargs["monitoring_path"]
@@ -40,9 +31,8 @@ class CheckQCHandler(tornado.web.RequestHandler):
         reports["version"] = checkqc_version
         return reports
 
-    @coroutine
     def get(self, runfolder):
-        reports = yield self.process_pool.submit(self._run_check_qc, self.monitor_path, self.qc_config_file, runfolder)
+        reports = self._run_check_qc(self.monitor_path, self.qc_config_file, runfolder)
         self.set_header("Content-Type", "application/json")
         self.write(reports)
 
@@ -60,12 +50,6 @@ class WebApp(object):
     def _make_app(debug=False, **kwargs):
         return tornado.web.Application(WebApp._routes(**kwargs), debug=debug)
 
-    @staticmethod
-    def _create_server(port, app):
-        server = tornado.httpserver.HTTPServer(app)
-        server.bind(port)
-        return server
-
     def start_web_app(self, monitoring_path, port, config_file, log_config, debug):
         logging_config_path = ConfigFactory.get_logging_config_dict(log_config)
         logging.config.dictConfig(logging_config_path)
@@ -76,12 +60,8 @@ class WebApp(object):
             log.error("{} is not a directory".format(monitoring_path))
             raise AssertionError("{} is not a directory".format(monitoring_path))
 
-        # See the comment above in the CheckQCHandler as to why this somewhat backward way
-        # is used to setup the server and ProcessPoolExecutor. /JD 2017-11-08
         web_app = self._make_app(monitoring_path=monitoring_path, qc_config_file=config_file, debug=debug)
-        server = self._create_server(port=port, app=web_app)
-        server.start()
-        CheckQCHandler.process_pool = ProcessPoolExecutor()
+        web_app.listen(port=port)
         tornado.ioloop.IOLoop.instance().start()
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -308,6 +308,38 @@ Here is an example how to query the endpoint, and what type of results it will r
   }
 
 
+Running CheckQC with Docker
+---------------------------
+
+For convenience, a Dockerfile is included. Containers started from the built image will have the service running on
+port 80 and will monitor the `tests/resources` folder by default. The monitored folder can be specified when starting
+the container.
+
+Example commands:
+
+Build the docker image:
+
+.. code-block :: console
+  docker build -t checkqc .
+
+Run the container using the default settings, mapping the host port 9999 to the container port 80:
+.. code-block :: console
+  docker run -p 9999:80 -d checkqc
+
+Run the container but specify the config file and mount a folder to monitor:
+
+.. code-block :: console
+  docker run -p 9999:80 -v /path/to/folder/on/host:/mnt/runfolders -d \
+       checkqc /mnt/runfolders --config=/path/to/config.yaml
+
+Note that for development and debugging, it is very convenient to mount a host folder containing the checkqc repo under the `/app` mount point in the container.
+The service will then run from that code and any changes you make to the code will take immediate effect on the
+running web service:
+
+.. code-block :: console
+  docker run -p 9999:80 -v /path/to/checkqc/repo/on/host:/app -d checkqc
+
+
 Developing CheckQC
 ------------------
 

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,4 +1,4 @@
 click==6.7
 PyYAML==3.12
-https://github.com/Illumina/interop/releases/download/v1.0.25/interop-1.0.25-cp36-cp36m-manylinux1_x86_64.whl
+interop
 xmltodict==0.11.0

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,20 +1,16 @@
 
-from concurrent.futures import ProcessPoolExecutor
 
 import tornado.web
 from tornado.testing import *
 
-from checkQC.web_app import WebApp, CheckQCHandler
+from checkQC.web_app import WebApp
 
 
 class TestWebApp(AsyncHTTPTestCase):
 
     def get_app(self):
-        routes = WebApp._routes(monitoring_path=os.path.join("tests", "resources"),
-                                qc_config_file=None)
-        CheckQCHandler.process_pool = ProcessPoolExecutor()
+        routes = WebApp._routes(monitoring_path=os.path.join("tests", "resources"), qc_config_file=None)
         return tornado.web.Application(routes)
-
 
     def test_qc_endpoint(self):
         response = self.fetch('/qc/170726_D00118_0303_BCB1TVANXX')


### PR DESCRIPTION
This PR removes the `ProcessPoolExecutor` functionality from the web service, basically reducing it to running things in a blocking fashion. The problem with the ProcessPoolExecutor was that it spawned a lot of threads that were left running and wouldn't terminate properly. The most straightforward way to fix it was, for now, to remove the threading. 

Obviously, there are more elegant ways to solve this so feel free to step up 😄 

In addition, a Dockerfile for running the service in a container has been added.