### PR TITLE
Automatically push tags to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: python
 python:
-  - "3.6"
-
+  - '3.6'
 install:
   - pip install -e . -r ./requirements/dev
-
 script:
   - pytest --cov=checkQC tests/
-
 after_success:
   - codecov
-
 notifications:
-    email: false
+  email: false
+deploy:
+  user: johandahlberg
+  password:
+    secure: ZDLFOkDScHCdDrgmGMOBY7+gENWcbhjoHCu2FOEJl4Wxbkda6euM9zcpcy7dFYDg3U2q9+xhrl4IBjVy46A9ir0KR9RZPhlGbBfIDWB1l+Hq8DlTtjiXg4FGviG28ERzaZ5aLsf5aMBF9ZAOsdCizOuR/V1KnB5fBFIJ5h49DtfP+j6Yd1yd6b3kXpi/FVxosxEMSDqUYQB3yZQs3kEJ1JQxjeQ/8rnoQnsh+hH5co5rdKYvQmNSkrRToMKj0AD8NsPQ1dQmyKVQFRoQdsap9HJpPIvpCf0o2vhd+T89BndZzlnfsrZ9bvUHHYv9+TrO5pzZieRHdFjdk+d5/L94ESJlvGOZnKcEGfvCcOYoVvTP2hynf0Igq4rDKeoUdvLa13Cms1yYWb/75VP/CMJArRCehO9XdIIJoOcZTR/hCFIoYlvF3OEL88mDxC0Jibv2ruzxEb6bxthN9lbF4XuJTPTa59jMtLmsbdcIAIRPFFpG94Pji8InV8df5NzTpCNJoCleAf9hA/tm88eyxv9aGYzRTabhcg9XfawAql0qfc58hcl7RTjw4s3ZnC1cZuMp1oQw6foaES3zxqc7zSNukR0qM8mB17DLuL0KMhSFTMpWhqXZVskXOJwBlCIFfgAuAYPd6+fm29m32dgJ6deWnzicJUplODn9cnfCFjk47mY=
+  distributions: sdist bdist_wheel
+  on:
+    tags: true


### PR DESCRIPTION
This should make all releases (i.e. tags) be pushed automatically to PyPI. Nice to take one more step out of the release process.