### PR TITLE
Adding Novaseq S1, S2, and S4 support

### DIFF
--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -187,7 +187,7 @@ novaseq_S2:
         error: unknown
       - name: ReadsPerSampleHandler
         warning: unknown
-        error: 325 # 50 % of threshold for clusters pass filter
+        error: 800 # 50 % of threshold for clusters pass filter
   101:
     handlers:
       - name: ClusterPFHandler
@@ -202,7 +202,7 @@ novaseq_S2:
         error: unknown
       - name: ReadsPerSampleHandler
         warning: unknown
-        error: 325 # 50 % of threshold for clusters pass filter
+        error: 800 # 50 % of threshold for clusters pass filter
   151:
     handlers:
       - name: ClusterPFHandler
@@ -217,7 +217,7 @@ novaseq_S2:
         error: unknown
       - name: ReadsPerSampleHandler
         warning: unknown
-        error: 325 # 50 % of threshold for clusters pass filter
+        error: 800 # 50 % of threshold for clusters pass filter
 
 novaseq_S4:
   151:

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -125,11 +125,41 @@ hiseqx_v2:
         warning: unknown
         error: 200 # 50 % of threshold for clusters pass filter
 
-novaseq_v1:
+novaseq_S1:
+  51:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 650 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 85 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 325 # 50 % of threshold for clusters pass filter
+  101:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 650 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 80 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 325 # 50 % of threshold for clusters pass filter
   151:
     handlers:
       - name: ClusterPFHandler
-        warning: 1400 # Millons of clusters
+        warning: 650 # Millons of clusters
         error: unknown
       - name: Q30Handler
         warning: 75 # Give percentage for reads greater than Q30
@@ -140,7 +170,71 @@ novaseq_v1:
         error: unknown
       - name: ReadsPerSampleHandler
         warning: unknown
-        error: 700 # 50 % of threshold for clusters pass filter
+        error: 325 # 50 % of threshold for clusters pass filter
+
+novaseq_S2:
+  51:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1600 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 85 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 325 # 50 % of threshold for clusters pass filter
+  101:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1600 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 80 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 325 # 50 % of threshold for clusters pass filter
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1600 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 75 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 325 # 50 % of threshold for clusters pass filter
+
+novaseq_S4:
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 2000 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 75 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 1000 # 50 % of threshold for clusters pass filter
 
 miseq_v2:
   51:

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -66,7 +66,11 @@ class NovaSeq(IlluminaInstrument):
 
     @staticmethod
     def reagent_version(runtype_recognizer):
-        return "v1"
+        try:
+            reagent_version = runtype_recognizer.run_parameters["RunParameters"]["RfidsInfo"]["FlowCellMode"]
+            return reagent_version
+        except KeyError:
+            raise ReagentVersionUnknown("Could not identify flowcell mode for Novaseq")
 
 
 class HiSeqX(IlluminaInstrument):

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -29,7 +29,7 @@ class TestRunTypeRecognizer(TestCase):
         self.assertEqual(expected, actual)
 
 
-class TestHiSeq2500(TestCase):
+class TestIlluminaInstrument(TestCase):
 
     class MockRunTypeRecognizer():
         def __init__(self, run_parameters):
@@ -81,12 +81,12 @@ class TestHiSeq2500(TestCase):
         with self.assertRaises(ReagentVersionUnknown):
             self.miseq.reagent_version(mock_runtype_recognizer)
 
-    def test_novaseq_reagent_version(self):
-        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2"}}
+    def test_novaseq_reagent_version_S1(self):
+        runtype_dict = {"RunParameters": {"RfidsInfo": {"FlowCellMode": "S1"}}}
         mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
 
         actual = self.novaseq.reagent_version(mock_runtype_recognizer)
-
-        expected = "novaseq_v1"
+        expected = "novaseq_S1"
 
         self.assertTrue(actual, expected)
+

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -46,9 +46,9 @@ class TestIlluminaInstrument(TestCase):
 
         actual = self.hiseq2500.reagent_version(mock_runtype_recognizer)
 
-        expected = "hiseq2500_rapidhighoutput_v4"
+        expected = "rapidhighoutput_v4"
 
-        self.assertTrue(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_wrong_runmode(self):
         runtype_dict = {"RunParameters": {"Setup": {"Sbs": "HiSeq SBS Kit v4"}}}
@@ -70,9 +70,9 @@ class TestIlluminaInstrument(TestCase):
 
         actual = self.miseq.reagent_version(mock_runtype_recognizer)
 
-        expected = "miseq_v2"
+        expected = "v2"
 
-        self.assertTrue(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_miseq_unknown_reagent_version(self):
         runtype_dict = {"RunParameters": {"foo": "bar"}}
@@ -86,9 +86,9 @@ class TestIlluminaInstrument(TestCase):
         mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
 
         actual = self.novaseq.reagent_version(mock_runtype_recognizer)
-        expected = "novaseq_S1"
+        expected = "S1"
 
-        self.assertTrue(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_novaseq_reagent_version_raises(self):
         runtype_dict = {"RunParameters": {"RfidsInfo": {"NoFlowCellMode": "S1"}}}

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -90,3 +90,9 @@ class TestIlluminaInstrument(TestCase):
 
         self.assertTrue(actual, expected)
 
+    def test_novaseq_reagent_version_raises(self):
+        runtype_dict = {"RunParameters": {"RfidsInfo": {"NoFlowCellMode": "S1"}}}
+        mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
+
+        with self.assertRaises(ReagentVersionUnknown):
+            self.novaseq.reagent_version(mock_runtype_recognizer)


### PR DESCRIPTION
Adding support for the S1, S2, and S4 modes of the NovaSeq. Changed name of test class which did not make sense.