### PR TITLE
Support for iSeq, and improved org for testing

### DIFF
--- a/checkQC/app.py
+++ b/checkQC/app.py
@@ -60,7 +60,7 @@ class App(object):
         try:
             config = ConfigFactory.from_config_path(self._config_file)
             parser_configurations = config.get("parser_configurations", None)
-            run_type_recognizer = RunTypeRecognizer(config=config, runfolder=self._runfolder)
+            run_type_recognizer = RunTypeRecognizer(runfolder=self._runfolder)
             instrument_and_reagent_version = run_type_recognizer.instrument_and_reagent_version()
 
             # TODO For now assume symmetric read lengths

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -314,3 +314,20 @@ miseq_v3:
       - name: ReadsPerSampleHandler
         warning: unknown
         error: 9 # 50 % of threshold for clusters pass filter
+
+iseq_v1:
+  36:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 8 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 85 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 1.5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 4 # 50 % of threshold for clusters pass filter

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -316,13 +316,13 @@ miseq_v3:
         error: 9 # 50 % of threshold for clusters pass filter
 
 iseq_v1:
-  36:
+  300:
     handlers:
       - name: ClusterPFHandler
-        warning: 8 # Millons of clusters
+        warning: 4 # Millons of clusters
         error: unknown
       - name: Q30Handler
-        warning: 85 # Give percentage for reads greater than Q30
+        warning: 80 # Give percentage for reads greater than Q30
         error: unknown # Give percentage for reads greater than Q30
       - name: ErrorRateHandler
         allow_missing_error_rate: False
@@ -330,4 +330,4 @@ iseq_v1:
         error: unknown
       - name: ReadsPerSampleHandler
         warning: unknown
-        error: 4 # 50 % of threshold for clusters pass filter
+        error: 2 # 50 % of threshold for clusters pass filter

--- a/checkQC/runfolder_reader.py
+++ b/checkQC/runfolder_reader.py
@@ -8,9 +8,21 @@ log = logging.getLogger(__name__)
 
 
 class RunfolderReader(object):
+    """
+    This class provides methods to read files such as the runParameters.xml and RunInfo.xml files, which
+    often need to be read to pick up info about what type of run we are looking at etc.
+    """
 
     @staticmethod
     def read_run_parameters_xml(runfolder):
+        """
+        Read the run parameters of an Illumina instrument are recorded in a file called
+        runParameters or RunParameters depending on the exact instrument type. This method
+        will read it and return it as a dict.
+        :param runfolder: to look in
+        :return: the [R|r]unParameters.xml as a dict
+        :raises: RunParametersNotFound if no [R|r]unParameters.xml was found
+        """
         try:
             with open(RunfolderReader.find_run_parameters_xml(runfolder)) as f:
                 return xmltodict.parse(f.read())
@@ -19,6 +31,11 @@ class RunfolderReader(object):
 
     @staticmethod
     def read_run_info_xml(runfolder):
+        """
+        Read the RunInfo.xml and return it as a dict
+        :param runfolder: to look in
+        :return: RunInfo.xml data as a dict
+        """
         try:
             run_info_path = os.path.join(runfolder, "RunInfo.xml")
             if not os.path.exists(run_info_path):
@@ -31,6 +48,11 @@ class RunfolderReader(object):
 
     @staticmethod
     def find_run_parameters_xml(runfolder):
+        """
+        Finds the path to the [r|R]unParameters.xml
+        :param runfolder: to look in
+        :return: the path to the [r|R]unParameters.xml
+        """
         first_option = os.path.join(runfolder, "RunParameters.xml")
         second_option = os.path.join(runfolder, "runParameters.xml")
         if os.path.isfile(first_option):

--- a/checkQC/runfolder_reader.py
+++ b/checkQC/runfolder_reader.py
@@ -1,0 +1,43 @@
+
+import xmltodict
+import os
+import logging
+from checkQC.exceptions import RunParametersNotFound, RunInfoXMLNotFound
+
+log = logging.getLogger(__name__)
+
+
+class RunfolderReader(object):
+
+    @staticmethod
+    def read_run_parameters_xml(runfolder):
+        try:
+            with open(RunfolderReader.find_run_parameters_xml(runfolder)) as f:
+                return xmltodict.parse(f.read())
+        except FileNotFoundError:
+            raise RunParametersNotFound("Could not find [R|r]unParameters.xml for runfolder {}".format(runfolder))
+
+    @staticmethod
+    def read_run_info_xml(runfolder):
+        try:
+            run_info_path = os.path.join(runfolder, "RunInfo.xml")
+            if not os.path.exists(run_info_path):
+                log.error("Could not find a RunInfo.xml in {}. Are you sure this is a runfolder?".format(run_info_path))
+                raise FileNotFoundError("Could not find {}".format(run_info_path))
+            with open(run_info_path) as f:
+                return xmltodict.parse(f.read())
+        except FileNotFoundError:
+            raise RunInfoXMLNotFound("Could not find RunInfo.xml at {}".format(run_info_path))
+
+    @staticmethod
+    def find_run_parameters_xml(runfolder):
+        first_option = os.path.join(runfolder, "RunParameters.xml")
+        second_option = os.path.join(runfolder, "runParameters.xml")
+        if os.path.isfile(first_option):
+            return first_option
+        elif os.path.isfile(second_option):
+            return second_option
+        else:
+            log.error("Could not find [R|r]unParameters.xml in directory {}. "
+                      "Are you sure this is a runfolder?".format(runfolder))
+            raise FileNotFoundError("Could not find [R|r]unParameters.xml for runfolder {}".format(runfolder))


### PR DESCRIPTION
This adds support for the Illumina iSeq, and also makes some changes to the way that the RuntypeRecognizer works by introducing a separate class for reading the files in the runfolder. This makes this easier to mock  in the tests, which makes it easier to test that the correct  instrument is returned 
 depending on which type of runfolder is passed  in.

The QC criteria that I have added are completely arbitrary, and need to be update.