### PR TITLE
iSeq instrument names start with FS

### DIFF
--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -176,7 +176,7 @@ class RunTypeRecognizer(object):
                                  "D": "hiseq2500",
                                  "ST": "hiseqx",
                                  "A": "novaseq",
-                                 "FFSP": "iseq"}
+                                 "FS": "iseq"}
 
         for key, value in machine_type_mappings.items():
             if instrument_name.startswith(key):

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -44,7 +44,7 @@ class TestRunTypeRecognizerCorrectInstrumentsReturned(TestCase):
         self.assertTrue(isinstance(actual, HiSeq2500))
 
     def test_returns_iseq(self):
-        runtyperecognizer = self._create_runtype_recognizer("FFSP100")
+        runtyperecognizer = self._create_runtype_recognizer("FS10000263")
         actual = runtyperecognizer.instrument_type()
         self.assertTrue(isinstance(actual, ISeq))
 


### PR DESCRIPTION
The documentation regarding iSeq naming conventions was incorrect, the naming convention for iSeqs should be that they start with FS.