### PR TITLE
CheckQC will ignore white-listed indexes

### DIFF
--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -22,7 +22,7 @@ default_handlers:
     # N{3,} will match three or more Ns.
     white_listed_indexes:
       - .*N.*
-      - G{8,}
+      - G{6,}
 
 hiseq2500_rapidhighoutput_v4:
   51-71:

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -15,7 +15,7 @@ default_handlers:
     error: 9 # <% Phix on lane> + < value as %>
   - name: UnidentifiedIndexHandler
     significance_threshold: 1 # % of reads in unidentified
-    # Indexes which are will not cause an error even if they occur
+    # Indexes which are white-listed will only cause a warning even if they occur
     # above the significance level.
     # They will be matched like regular expressions,
     # so e.g. NNN will match exactly three NNNs, while

--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -1,5 +1,3 @@
-
-
 # For information about config usage, see http://checkqc.readthedocs.io/en/latest/#configuration-file
 
 # Use this section to provide configuration options to the parsers
@@ -12,11 +10,19 @@ parser_configurations:
     samplesheet_name: SampleSheet.csv
 
 default_handlers:
-    - name: UndeterminedPercentageHandler
-      warning: unknown
-      error: 9 # <% Phix on lane> + < value as %>
-    - name: UnidentifiedIndexHandler
-      significance_threshold: 1 # % of reads in unidentified
+  - name: UndeterminedPercentageHandler
+    warning: unknown
+    error: 9 # <% Phix on lane> + < value as %>
+  - name: UnidentifiedIndexHandler
+    significance_threshold: 1 # % of reads in unidentified
+    # Indexes which are will not cause an error even if they occur
+    # above the significance level.
+    # They will be matched like regular expressions,
+    # so e.g. NNN will match exactly three NNNs, while
+    # N{3,} will match three or more Ns.
+    white_listed_indexes:
+      - .*N.*
+      - G{8,}
 
 hiseq2500_rapidhighoutput_v4:
   51-71:

--- a/checkQC/handlers/unidentified_index_handler.py
+++ b/checkQC/handlers/unidentified_index_handler.py
@@ -87,10 +87,10 @@ class UnidentifiedIndexHandler(QCHandler):
         # Unknown index means that the sample was run without an index.
         # Ns indicate errors in read
         return not tag == 'unknown' and \
-               not self.tag_in_white_list(tag) and \
+               not self._tag_in_white_list(tag) and \
                self.is_significantly_represented(count, number_of_reads_on_lane)
 
-    def tag_in_white_list(self, tag):
+    def _tag_in_white_list(self, tag):
         # This preserves backward compatiblity for users that do not specify
         # the 'white_listed_indexes' in their configs. /JD 2019-06-12
         if not self.qc_config.get(self.WHITE_LIST_QC_KEY):
@@ -100,8 +100,7 @@ class UnidentifiedIndexHandler(QCHandler):
                 pattern = re.compile(regex)
                 if pattern.match(tag):
                     return True
-                else:
-                    return False
+            return False
 
     def is_significantly_represented(self, index_count, nbr_of_reads_on_lane):
         return (float(index_count) / nbr_of_reads_on_lane) > \

--- a/tests/handlers/test_unidentified_index_handler.py
+++ b/tests/handlers/test_unidentified_index_handler.py
@@ -23,8 +23,12 @@ class TestUnidentifiedIndexHandlerIntegrationTest(HandlerTestBase):
         parsers = [DemuxSummaryParser(runfolder, config),
                    StatsJsonParser(runfolder, config),
                    SamplesheetParser(runfolder, config)]
-
-        qc_config = {'name': 'UnidentifiedIndexHandler', 'significance_threshold': 0.01}
+        qc_config = {
+            'name': 'UnidentifiedIndexHandler',
+            'significance_threshold': 0.01,
+            'white_listed_indexes':
+                ['.*N.*', 'G{8,}']
+            }
         self.unidentified_index_handler = UnidentifiedIndexHandler(qc_config)
         for parser in parsers:
             parser.add_subscribers(self.unidentified_index_handler)
@@ -40,12 +44,16 @@ class TestUnidentifiedIndexHandler(HandlerTestBase):
 
     def setUp(self):
 
-        qc_config = {'name': 'UnidentifiedIndexHandler', 'significance_threshold': 1}
+        qc_config = {
+            'name': 'UnidentifiedIndexHandler',
+            'significance_threshold': 1,
+            'white_listed_indexes':
+                ['.*N.*', 'G{8,}']
+            }
         self.unidentifiedIndexHandler = UnidentifiedIndexHandler(qc_config)
 
         conversion_results_key = "ConversionResults"
         conversion_results = get_stats_json()["ConversionResults"]
-
         samplesheet_key = "samplesheet"
         self.samplesheet = SampleSheet()
         sample_1 = Sample(dict(Lane=1, Sample_ID='1823A', Sample_Name='1823A-tissue', index='AAAA'))
@@ -77,8 +85,17 @@ class TestUnidentifiedIndexHandler(HandlerTestBase):
         self.assertFalse(self.unidentifiedIndexHandler.should_be_evaluated(tag='AAAAAA',
                                                                            count=1,
                                                                            number_of_reads_on_lane=1000))
+        # No
+        self.assertFalse(self.unidentifiedIndexHandler.should_be_evaluated(tag='GGGGGGGG',
+                                                                           count=1,
+                                                                           number_of_reads_on_lane=1000))
+
         # Yes
         self.assertTrue(self.unidentifiedIndexHandler.should_be_evaluated(tag='AAAAAA',
+                                                                          count=100,
+                                                                          number_of_reads_on_lane=1000))
+        # Yes
+        self.assertTrue(self.unidentifiedIndexHandler.should_be_evaluated(tag='GGGGGG',
                                                                           count=100,
                                                                           number_of_reads_on_lane=1000))
 

--- a/tests/handlers/test_unidentified_index_handler.py
+++ b/tests/handlers/test_unidentified_index_handler.py
@@ -87,7 +87,7 @@ class TestUnidentifiedIndexHandler(HandlerTestBase):
                                                                            number_of_reads_on_lane=1000))
         # No
         self.assertFalse(self.unidentifiedIndexHandler.should_be_evaluated(tag='GGGGGGGG',
-                                                                           count=1,
+                                                                           count=100,
                                                                            number_of_reads_on_lane=1000))
 
         # Yes
@@ -98,6 +98,39 @@ class TestUnidentifiedIndexHandler(HandlerTestBase):
         self.assertTrue(self.unidentifiedIndexHandler.should_be_evaluated(tag='GGGGGG',
                                                                           count=100,
                                                                           number_of_reads_on_lane=1000))
+    
+    def test_should_be_evaluated_backwards_compatible(self):
+        # No white list in config (which was the old behaviour)
+        qc_config = {
+            'name': 'UnidentifiedIndexHandler',
+            'significance_threshold': 1}
+        unidentifiedIndexHandler = UnidentifiedIndexHandler(qc_config)
+
+        # No
+        self.assertFalse(unidentifiedIndexHandler.should_be_evaluated(tag='unknown',
+                                                                      count=1,
+                                                                      number_of_reads_on_lane=10))
+        # No
+        self.assertFalse(unidentifiedIndexHandler.should_be_evaluated(tag='AAATGCNNNN',
+                                                                      count=1,
+                                                                      number_of_reads_on_lane=10))
+        # No
+        self.assertFalse(unidentifiedIndexHandler.should_be_evaluated(tag='AAAAAA',
+                                                                      count=1,
+                                                                      number_of_reads_on_lane=1000))
+        # Yes
+        self.assertTrue(unidentifiedIndexHandler.should_be_evaluated(tag='GGGGGGGG',
+                                                                     count=100,
+                                                                     number_of_reads_on_lane=1000))
+
+        # Yes
+        self.assertTrue(unidentifiedIndexHandler.should_be_evaluated(tag='AAAAAA',
+                                                                     count=100,
+                                                                     number_of_reads_on_lane=1000))
+        # Yes
+        self.assertTrue(unidentifiedIndexHandler.should_be_evaluated(tag='GGGGGG',
+                                                                     count=100,
+                                                                     number_of_reads_on_lane=1000))
 
     def test_get_complementary_sequence(self):
         res = self.unidentifiedIndexHandler.get_complementary_sequence('ATCG+N')


### PR DESCRIPTION
This makes CheckQC ignore any index that is listed in `white_listed_indexes`, in the configuration. These can be specified as regular expressions, so it should be fairly flexible how you to specify them.

Which indexes would you like to have as default in the whitelist, @MatildaAslin and @sarek928?