### PR TITLE
Option to use closest read length

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -237,6 +237,24 @@ This parameter can be supplied to the webservice as a query argument:
 
   curl -s -w'\n' localhost:9999/qc/170726_D00118_0303_BCB1TVANXX?downgrade=ReadsPerSampleHandler,UndeterminedPercentageHandler | python -m json.tool
 
+  Use closest read length
+  ------------------------------
+
+  It is possible to instruct CheckQC to use the closest read length if the read length of the run is not found in the config.
+  In case of a tie between two read lengths, the longer read length (with stricter QC criteria) will be used.
+
+  Usage:
+
+  .. code-block :: console
+
+    $ checkqc --use-closest-read-length <RUNFOLDER>
+
+  This parameter can be supplied to the webservice as a query argument:
+
+  .. code-block :: console
+
+    curl -s -w'\n' localhost:9999/qc/170726_D00118_0303_BCB1TVANXX?useClosestReadLength | python -m json.tool
+
 Running CheckQC as a webservice
 -------------------------------
 

--- a/tests/resources/read_length_not_in_config.yaml
+++ b/tests/resources/read_length_not_in_config.yaml
@@ -1,0 +1,45 @@
+# NOTE
+# ----
+# This config is a partial copy of checkQC/default_config/config.yaml,
+# where the read length 126 is not specified for hiseq2500_rapidhighoutput_v4
+
+# Use this section to provide configuration options to the parsers
+parser_configurations:
+  StatsJsonParser:
+    # Path to where the bcl2fastq output (i.e. fastq files, etc) is located relative to
+    # the runfolder
+    bcl2fastq_output_path: Data/Intensities/BaseCalls
+  SamplesheetParser:
+    samplesheet_name: SampleSheet.csv
+
+default_handlers:
+  - name: UndeterminedPercentageHandler
+    warning: unknown
+    error: 9 # <% Phix on lane> + < value as %>
+  - name: UnidentifiedIndexHandler
+    significance_threshold: 1 # % of reads in unidentified
+    # Indexes which are white-listed will only cause a warning even if they occur
+    # above the significance level.
+    # They will be matched like regular expressions,
+    # so e.g. NNN will match exactly three NNNs, while
+    # N{3,} will match three or more Ns.
+    white_listed_indexes:
+      - .*N.*
+      - G{6,}
+
+hiseq2500_rapidhighoutput_v4:
+  131:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 180 # Millons of clusters
+        error: unknown
+      - name: Q30Handler
+        warning: 80 # Give percentage for reads greater than Q30
+        error: unknown # Give percentage for reads greater than Q30
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 90 # 50 % of threshold for clusters pass filter

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,11 +19,16 @@ class TestApp(unittest.TestCase):
         # The test data contains fatal qc errors
         self.assertEqual(app.run(), 1)
 
+    def test_run_use_closest_read_length(self):
+        config_file = os.path.join("tests", "resources", "read_length_not_in_config.yaml")
+        app = App(runfolder=self.RUNFOLDER, config_file=config_file, use_closest_read_length=True)
+        # The test data contains fatal qc errors
+        self.assertEqual(app.run(), 1)
+
     def test_run_downgrade_error(self):
         app = App(runfolder=self.RUNFOLDER, downgrade_errors_for="ReadsPerSampleHandler")
         # Test data should not produce fatal qc errors anymore
         self.assertEqual(app.run(), 0)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,12 @@ class TestConfig(unittest.TestCase):
                            '150-299': {'handlers': [
                                self.second_handler]}
                        },
+                       'hiseqx': {
+                           50: {'handlers': [
+                               self.first_handler]},
+                           52: {'handlers': [
+                               self.second_handler]}
+                       },
                        "default_handlers": [
                            self.default_handler,
                            self.first_handler
@@ -54,6 +60,18 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(len(result), len(handler_list))
         self.assertEqual(result[1]["error"], "unknown")
         self.assertEqual(result[1]["warning"], 100)
+
+    def test_use_closest_read_length(self):
+        result = self.config._get_matching_handler('miseq_v3', 149, use_closest_read_length=True)
+        self.assertEqual(result, [self.second_handler])
+
+    def test_use_closest_read_length_in_the_middle(self):
+        result = self.config._get_matching_handler('hiseqx', 51, use_closest_read_length=True)
+        self.assertEqual(result, [self.second_handler])
+
+    def test_machine_and_reagent_type_not_found(self):
+        with self.assertRaises(ConfigEntryMissing):
+            self.config._get_matching_handler('foo', 51, use_closest_read_length=True)
 
 
 class TestConfigFactory(unittest.TestCase):


### PR DESCRIPTION
This PR adds an option to use the closest read length found in the config, if the one used isn't found. In case of a tie between two read length, the longer one (with stricter QC criteria) will be used. 

