### PR TITLE
Remove unused requirements file

### DIFF
--- a/requirements/readthedocs
+++ b/requirements/readthedocs
@@ -1,4 +1,0 @@
-click==6.7
-PyYAML==3.12
-https://github.com/Illumina/interop/releases/download/v1.0.25/interop-1.0.25-cp35-cp35m-manylinux1_x86_64.whl
-xmltodict==0.11.0


### PR DESCRIPTION
When trying to verify if the changes in #91 had fixed the API docs I found another build problem. It was caused by the `requirements/readthedocs` not being up to date. I have now changed the settings on readthedocs so that `requirements/prod` is used instead, hence we do not need this file anymore. 

Building of docs are now successful and it contains the API section 🎉 