### PR TITLE
DEVELOP-2147: Add support for Miseq Nano and Micro

### DIFF
--- a/checkQC/default_config/config.yaml
+++ b/checkQC/default_config/config.yaml
@@ -43,7 +43,7 @@ hiseq2500_rapidhighoutput_v4:
   100-111:
     handlers:
       - name: ClusterPFHandler
-        warning: 180 
+        warning: 180
         error: unknown
       - name: Q30Handler
         warning: 80
@@ -322,6 +322,55 @@ novaseq_S4:
       - name: ReadsPerSampleHandler
         warning: unknown
         error: 1500
+
+miseq_nano_v2:
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 7.5
+  251:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 1
+        error: unknown
+      - name: Q30Handler
+        warning: 75
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 5
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 7.5
+
+miseq_micro_v2:
+  151:
+    handlers:
+      - name: ClusterPFHandler
+        warning: 4
+        error: unknown
+      - name: Q30Handler
+        warning: 80
+        error: unknown
+      - name: ErrorRateHandler
+        allow_missing_error_rate: False
+        warning: 2
+        error: unknown
+      - name: ReadsPerSampleHandler
+        warning: unknown
+        error: 7.5
 
 miseq_v2:
   51:

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -115,7 +115,7 @@ class MiSeq(IlluminaInstrument):
 
         def _flowcell_type(runtype_recognizer):
             try:
-                tiles_per_swath = runtype_recognizer.run_parameters["RunParameters"]["Setup"]["NumTilesPerSwath"]
+                tiles_per_swath = int(runtype_recognizer.run_parameters["RunParameters"]["Setup"]["NumTilesPerSwath"])
                 if tiles_per_swath == 2:
                     return "nano"
                 elif tiles_per_swath == 4:

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -122,7 +122,9 @@ class MiSeq(IlluminaInstrument):
                     return "micro"
                 elif tiles_per_swath >= 14:
                     return "standard"
-            except KeyError:
+                else:
+                    raise ReagentVersionUnknown()
+            except (KeyError, ReagentVersionUnknown):
                 raise ReagentVersionUnknown("Unable to identify flowcell type through number of tiles per swath")
 
         flowcell_version = _flowcell_type(runtype_recognizer)

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -115,6 +115,15 @@ class TestIlluminaInstrument(TestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_miseq_reagent_version_unrecognized_number_of_tiles(self):
+        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 3}}}
+        mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
+
+        with self.assertRaises(ReagentVersionUnknown) as cm:
+            self.miseq.reagent_version(mock_runtype_recognizer)
+            self.assertEqual(cm.exception,
+                             "Unable to identify flowcell type through number of tiles per swath")
+
     def test_miseq_unknown_reagent_version(self):
         runtype_dict = {"RunParameters": {"foo": "bar"}}
         mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -85,8 +85,38 @@ class TestIlluminaInstrument(TestCase):
         with self.assertRaises(ReagentVersionUnknown):
             self.hiseq2500.reagent_version(mock_runtype_recognizer)
 
-    def test_miseq_reagent_version(self):
-        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2"}}
+    def test_miseq_reagent_version_nano(self):
+        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 2}}}
+        mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
+
+        actual = self.miseq.reagent_version(mock_runtype_recognizer)
+
+        expected = "nano_v2"
+
+        self.assertEqual(actual, expected)
+
+    def test_miseq_reagent_version_micro(self):
+        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 4}}}
+        mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
+
+        actual = self.miseq.reagent_version(mock_runtype_recognizer)
+
+        expected = "micro_v2"
+
+        self.assertEqual(actual, expected)
+
+    def test_miseq_reagent_version_micro(self):
+        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 4}}}
+        mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
+
+        actual = self.miseq.reagent_version(mock_runtype_recognizer)
+
+        expected = "micro_v2"
+
+        self.assertEqual(actual, expected)
+
+    def test_miseq_reagent_version_standard(self):
+        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 14}}}
         mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
 
         actual = self.miseq.reagent_version(mock_runtype_recognizer)

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -105,16 +105,6 @@ class TestIlluminaInstrument(TestCase):
 
         self.assertEqual(actual, expected)
 
-    def test_miseq_reagent_version_micro(self):
-        runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 4}}}
-        mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)
-
-        actual = self.miseq.reagent_version(mock_runtype_recognizer)
-
-        expected = "micro_v2"
-
-        self.assertEqual(actual, expected)
-
     def test_miseq_reagent_version_standard(self):
         runtype_dict = {"RunParameters": {"ReagentKitVersion": "Version2", "Setup": {"NumTilesPerSwath": 14}}}
         mock_runtype_recognizer = self.MockRunTypeRecognizer(run_parameters=runtype_dict)


### PR DESCRIPTION
This PR adds support for special MiSeq flowcells (nano and micro) that generates less data than the standard one.

@mikaelamo It would be nice if you could review the changes in config.yaml since you are familiar with INS-00123. :) 