### PR TITLE
Develop 2548 add nova seq x support

### DIFF
--- a/checkQC/handlers/unidentified_index_handler.py
+++ b/checkQC/handlers/unidentified_index_handler.py
@@ -10,24 +10,28 @@ from checkQC.exceptions import ConfigurationError
 
 class UnidentifiedIndexHandler(QCHandler):
     """
-    The UnidentifiedIndexHandler will try to identify if an index is represented at to high a level in unidentified
-    reads, and if that is the case try to pinpoint why that is.
+    The UnidentifiedIndexHandler will try to identify if an index is
+    represented at to high a level in unidentified reads, and if that is the
+    case try to pinpoint why that is.
 
-    It will not output errors, but all information will be displayed as warnings, due to the difficulty
-    of deciding what is an error or not in this context. For most cases the % of unidentified reads will be what
-    is used to issue the error, and then the warnings from this handler can help in identifying the
-    possible underlying cause.
+    It will not output errors, but all information will be displayed as
+    warnings, due to the difficulty of deciding what is an error or not in this
+    context. For most cases the % of unidentified reads will be what is used to
+    issue the error, and then the warnings from this handler can help in
+    identifying the possible underlying cause.
 
-    There are a number of different checks (or rules) in place, which will be checked if and index
-    occurs more then the `significance_threshold`. The samplesheet will be checked to see if the index
-    found matches and of the following rules:
-     - Check if the dual indexes have been swapped
-     - Check if the index has been reversed
-     - Check if the index is the reverse complement
-     - Check if the index is the complementary index
-     - Check if the index is present in another lane
+    There are a number of different checks (or rules) in place, which will be
+    checked if and index occurs more then the `significance_threshold`. The
+    samplesheet will be checked to see if the index found matches and of the
+    following rules:
+    - Check if the dual indexes have been swapped
+    - Check if the index has been reversed
+    - Check if the index is the reverse complement
+    - Check if the index is the complementary index
+    - Check if the index is present in another lane
 
-    It will ignore any indexes which have N's in them. These are assumed to be read errors.
+    It will ignore any indexes which have N's in them. These are assumed to be
+    read errors.
     """
 
     WHITE_LIST_QC_KEY = 'white_listed_indexes'

--- a/checkQC/run_type_recognizer.py
+++ b/checkQC/run_type_recognizer.py
@@ -200,7 +200,7 @@ class RunTypeRecognizer(object):
         }
 
         for instrument_code, instrument_class in machine_type_mappings.items():
-            if instrument_name.startswith(instrument_code):
+            if instrument_name.upper().startswith(instrument_code):
                 return instrument_class()
 
         raise InstrumentTypeUnknown("Did not recognize instrument type of: {}".format(instrument_name))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ release = ''
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,6 @@ import sys
 sys.path.insert(0, os.path.abspath('../checkQC'))
 
 
-from recommonmark.parser import CommonMarkParser
-
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -34,8 +31,11 @@ from recommonmark.parser import CommonMarkParser
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.viewcode']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'myst_parser',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -171,10 +171,6 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-
-source_parsers = {
-            '.md': CommonMarkParser,
-            }
 
 source_suffix = ['.rst', '.md']
 

--- a/requirements/dev
+++ b/requirements/dev
@@ -3,4 +3,6 @@ pytest~=7.3.1
 pytest-cov~=4.0.0
 codecov~=2.1.13
 sphinx-autobuild~=2021.3.14
+myst-parser~=1.0.0
+sphinx<7
 mock

--- a/requirements/dev
+++ b/requirements/dev
@@ -1,6 +1,5 @@
 -r prod
-pytest==3.1.2
-pytest-cov==2.5.1
-codecov==2.0.9
-sphinx-autobuild==0.7.1
-mock
+pytest~=7.3.1
+pytest-cov~=4.0.0
+codecov~=2.1.13
+sphinx-autobuild~=2021.3.14

--- a/requirements/dev
+++ b/requirements/dev
@@ -3,3 +3,4 @@ pytest~=7.3.1
 pytest-cov~=4.0.0
 codecov~=2.1.13
 sphinx-autobuild~=2021.3.14
+mock

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,5 +1,5 @@
-click==6.7
-PyYAML==6.0
-interop>=1.1.10
-xmltodict==0.11.0
-sample_sheet
+click~=8.0.1
+PyYAML~=6.0
+interop>=1.2.3
+xmltodict~=0.13.0
+sample_sheet~=0.13.0

--- a/tests/test_run_type_recognizer.py
+++ b/tests/test_run_type_recognizer.py
@@ -48,6 +48,16 @@ class TestRunTypeRecognizerCorrectInstrumentsReturned(TestCase):
         actual = runtyperecognizer.instrument_type()
         self.assertTrue(isinstance(actual, ISeq))
 
+    def test_case_insensitive(self):
+        runtyperecognizer = self._create_runtype_recognizer("lh1234")
+        actual = runtyperecognizer.instrument_type()
+        self.assertTrue(isinstance(actual, NovaSeqXPlus))
+
+        runtyperecognizer = self._create_runtype_recognizer("LH1234")
+        actual = runtyperecognizer.instrument_type()
+        self.assertTrue(isinstance(actual, NovaSeqXPlus))
+
+
 
 class TestIlluminaInstrument(TestCase):
 


### PR DESCRIPTION
This PR updates CheckQC's dependencies, and specifically `interop`, which is needed to process the new runfolder.

It also makes instrument detection case insensitive and adds tests for that.