### PR TITLE
Update dependencies

### DIFF
--- a/requirements/dev
+++ b/requirements/dev
@@ -1,8 +1,8 @@
 -r prod
-pytest~=7.3.1
-pytest-cov~=4.0.0
+pytest~=7.4.0
+pytest-cov~=4.1.0
 codecov~=2.1.13
 sphinx-autobuild~=2021.3.14
 myst-parser~=1.0.0
-sphinx<7
-mock
+sphinx~=7.0.1
+mock~=5.0.2

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,5 +1,6 @@
-click~=8.0.1
+click~=8.1.1
 PyYAML~=6.0
-interop>=1.2.3
+interop~=1.2.4
 xmltodict~=0.13.0
+tornado~=6.3.2
 sample_sheet~=0.13.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "click",
         "PyYAML>=6.0",
-        "interop>=1.1.10",
+        "interop>=1.2.3",
         "xmltodict",
         "tornado",
         "sample_sheet"],


### PR DESCRIPTION
This PR updates CheckQC's dependencies:
* `interop>=1.2.3` is required to support the new NovaSeqX instrument
* updates pinned dependencies to the last version of each package.