### PR TITLE
Fixed reads given multiple lanes

### DIFF
--- a/checkQC/handlers/q30_handler.py
+++ b/checkQC/handlers/q30_handler.py
@@ -30,17 +30,24 @@ class Q30Handler(QCHandler):
 
         index_count = 0
         non_index_count = 0
+        lane_no = 1
+
         for error_dict in self.error_results:
             lane_nbr = int(error_dict["lane"])
+            # restart counters for different lanes
+            if lane_nbr != lane_no:
+                index_count = 0
+                non_index_count = 0
+                lane_no = lane_nbr
+
             percent_q30 = error_dict["percent_q30"]
             is_index_read = error_dict.get("is_index_read", False)
             read_or_index_text = "index read" if is_index_read else "read"
             # Differentiate read values for indexed from non-indexed reads
             index_count += 1 if is_index_read else 0
             non_index_count += 1 if not is_index_read else 0
-            
             read = index_count if is_index_read else non_index_count
-            
+
             if self.error() != self.UNKNOWN and percent_q30 < self.error():
                 yield QCErrorFatal(
                     "%Q30 {:.2f} was too low on lane: {} for {}: {}".format(

--- a/checkQC/handlers/q30_handler.py
+++ b/checkQC/handlers/q30_handler.py
@@ -27,13 +27,11 @@ class Q30Handler(QCHandler):
             self.error_results.append(value)
 
     def check_qc(self):
-
-        index_count = 0
-        non_index_count = 0
-        lane_no = 1
+        lane_no = 0
 
         for error_dict in self.error_results:
             lane_nbr = int(error_dict["lane"])
+
             # restart counters for different lanes
             if lane_nbr != lane_no:
                 index_count = 0

--- a/tests/handlers/test_q30_handler.py
+++ b/tests/handlers/test_q30_handler.py
@@ -56,13 +56,24 @@ class TestQ30Handler(HandlerTestBase):
         errors_and_warnings = list(self.q30_handler.check_qc())
         self.assertEqual(len(errors_and_warnings), 8)
 
-        class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
-        self.assertListEqual(
-            class_names,
-            [
-                "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal",
-            ],
+        self.assertEqual(
+            str(errors_and_warnings),
+            str("[Fatal QC error: %Q30 82.00 was too low on lane: 1 for read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 2, Fatal QC error: %Q30 60.00 was too low on lane: 1 for read: 2, Fatal QC error: %Q30 90.00 was too low on lane: 2 for read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 2 for index read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 2 for read: 2, Fatal QC error: %Q30 40.00 was too low on lane: 2 for read: 3]")
         )
+
+    def test_max_read(self):
+        qc_config = {"name": "Q30Handler", "error": 99, "warning": 99}
+        self.set_qc_config(qc_config)
+        errors_and_warnings = list(self.q30_handler.check_qc())
+        self.assertEqual(len(errors_and_warnings), 8)
+
+        [
+            self.assertLessEqual(
+                int(str(read).split("read: ")[1]), 4
+            ) 
+            for read in errors_and_warnings
+        ]
+    
 
 
 if __name__ == "__main__":

--- a/tests/handlers/test_q30_handler.py
+++ b/tests/handlers/test_q30_handler.py
@@ -16,7 +16,7 @@ class TestQ30Handler(HandlerTestBase):
         value_4 = {"lane": 1, "read": 4, "percent_q30": 60}
         value_5 = {"lane": 2, "read": 1, "percent_q30": 90}
         value_6 = {"lane": 2, "read": 2, "percent_q30": 50, "is_index_read": True}
-        value_7 = {"lane": 2, "read": 3, "percent_q30": 50, "is_index_read": False}
+        value_7 = {"lane": 2, "read": 3, "percent_q30": 50}
         value_8 = {"lane": 2, "read": 4, "percent_q30": 40}
         q30_handler = Q30Handler(qc_config)
         q30_handler.collect((key, value_1))
@@ -33,27 +33,21 @@ class TestQ30Handler(HandlerTestBase):
         self.q30_handler.qc_config = qc_config
 
     def test_all_is_fine(self):
-        qc_config = {"name": "Q30Handler", "error": 70, "warning": 80}
+        qc_config = {"name": "Q30Handler", "error": 20, "warning": 30}
         self.set_qc_config(qc_config)
         errors_and_warnings = list(self.q30_handler.check_qc())
-        self.assertIn("index read", f"{errors_and_warnings}")
-        self.assertEqual(
-            f"{errors_and_warnings}",
-            "[Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 2, Fatal QC error: %Q30 60.00 was too low on lane: 1 for read: 2, Fatal QC error: %Q30 50.00 was too low on lane: 2 for index read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 2 for read: 2, Fatal QC error: %Q30 40.00 was too low on lane: 2 for read: 3]",
-        )
+        self.assertEqual(errors_and_warnings, [])
 
     def test_warning(self):
-        qc_config = {"name": "Q30Handler", "error": 70, "warning": 85}
+        qc_config = {"name": "Q30Handler", "error": 40, "warning": 60}
         self.set_qc_config(qc_config)
         errors_and_warnings = list(self.q30_handler.check_qc())
-        self.assertEqual(len(errors_and_warnings), 7)
+        self.assertEqual(len(errors_and_warnings), 5)
 
         class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
         self.assertListEqual(
             class_names,
-            [
-                "QCErrorWarning", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal",
-            ],
+            ["QCErrorWarning", "QCErrorWarning", "QCErrorWarning", "QCErrorWarning", "QCErrorWarning"],
         )
 
     def test_error(self):
@@ -68,18 +62,6 @@ class TestQ30Handler(HandlerTestBase):
             [
                 "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal",
             ],
-        )
-
-    def test_error_low_qc_marks(self):
-        qc_config = {"name": "Q30Handler", "error": 40, "warning": 60}
-        self.set_qc_config(qc_config)
-        errors_and_warnings = list(self.q30_handler.check_qc())
-        self.assertEqual(len(errors_and_warnings), 5)
-
-        class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
-        self.assertListEqual(
-            class_names,
-            ["QCErrorWarning", "QCErrorWarning", "QCErrorWarning", "QCErrorWarning", "QCErrorWarning"],
         )
 
 

--- a/tests/handlers/test_q30_handler.py
+++ b/tests/handlers/test_q30_handler.py
@@ -9,43 +9,79 @@ class TestQ30Handler(HandlerTestBase):
 
     def setUp(self):
         key = "percent_q30"
-        qc_config = {'name': 'Q30Handler', 'error': 70, 'warning': 80}
+        qc_config = {"name": "Q30Handler", "error": 70, "warning": 80}
         value_1 = {"lane": 1, "read": 1, "percent_q30": 82}
-        value_2 = {"lane": 1, "read": 2, "percent_q30": 90}
-        value_3 = {"lane": 1, "read": 3, "percent_q30": 50, "is_index_read": True}
+        value_2 = {"lane": 1, "read": 2, "percent_q30": 50, "is_index_read": True} 
+        value_3 = {"lane": 1, "read": 3, "percent_q30": 50, "is_index_read": True} 
+        value_4 = {"lane": 1, "read": 4, "percent_q30": 60}
+        value_5 = {"lane": 2, "read": 1, "percent_q30": 90}
+        value_6 = {"lane": 2, "read": 2, "percent_q30": 50, "is_index_read": True}
+        value_7 = {"lane": 2, "read": 3, "percent_q30": 50, "is_index_read": False}
+        value_8 = {"lane": 2, "read": 4, "percent_q30": 40}
         q30_handler = Q30Handler(qc_config)
         q30_handler.collect((key, value_1))
         q30_handler.collect((key, value_2))
         q30_handler.collect((key, value_3))
+        q30_handler.collect((key, value_4))
+        q30_handler.collect((key, value_5))
+        q30_handler.collect((key, value_6))
+        q30_handler.collect((key, value_7))
+        q30_handler.collect((key, value_8))
         self.q30_handler = q30_handler
 
     def set_qc_config(self, qc_config):
         self.q30_handler.qc_config = qc_config
 
     def test_all_is_fine(self):
-        qc_config = {'name': 'Q30Handler', 'error': 70, 'warning': 80}
+        qc_config = {"name": "Q30Handler", "error": 70, "warning": 80}
         self.set_qc_config(qc_config)
         errors_and_warnings = list(self.q30_handler.check_qc())
         self.assertIn("index read", f"{errors_and_warnings}")
-        self.assertEqual(f"{errors_and_warnings}", "[Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 1]")
+        self.assertEqual(
+            f"{errors_and_warnings}",
+            "[Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 1 for index read: 2, Fatal QC error: %Q30 60.00 was too low on lane: 1 for read: 2, Fatal QC error: %Q30 50.00 was too low on lane: 2 for index read: 1, Fatal QC error: %Q30 50.00 was too low on lane: 2 for read: 2, Fatal QC error: %Q30 40.00 was too low on lane: 2 for read: 3]",
+        )
 
     def test_warning(self):
-        qc_config = {'name': 'Q30Handler', 'error': 70, 'warning': 85}
+        qc_config = {"name": "Q30Handler", "error": 70, "warning": 85}
         self.set_qc_config(qc_config)
         errors_and_warnings = list(self.q30_handler.check_qc())
-        self.assertEqual(len(errors_and_warnings), 2)
+        self.assertEqual(len(errors_and_warnings), 7)
 
         class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
-        self.assertListEqual(class_names, ['QCErrorWarning', 'QCErrorFatal'])
+        self.assertListEqual(
+            class_names,
+            [
+                "QCErrorWarning", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal",
+            ],
+        )
 
     def test_error(self):
-        qc_config = {'name': 'Q30Handler', 'error': 95, 'warning': 98}
+        qc_config = {"name": "Q30Handler", "error": 95, "warning": 98}
         self.set_qc_config(qc_config)
         errors_and_warnings = list(self.q30_handler.check_qc())
-        self.assertEqual(len(errors_and_warnings), 3)
+        self.assertEqual(len(errors_and_warnings), 8)
 
         class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
-        self.assertListEqual(class_names, ['QCErrorFatal', 'QCErrorFatal', 'QCErrorFatal'])
+        self.assertListEqual(
+            class_names,
+            [
+                "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal", "QCErrorFatal",
+            ],
+        )
 
-if __name__ == '__main__':
+    def test_error_low_qc_marks(self):
+        qc_config = {"name": "Q30Handler", "error": 40, "warning": 60}
+        self.set_qc_config(qc_config)
+        errors_and_warnings = list(self.q30_handler.check_qc())
+        self.assertEqual(len(errors_and_warnings), 5)
+
+        class_names = self.map_errors_and_warnings_to_class_names(errors_and_warnings)
+        self.assertListEqual(
+            class_names,
+            ["QCErrorWarning", "QCErrorWarning", "QCErrorWarning", "QCErrorWarning", "QCErrorWarning"],
+        )
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The code below is a fix for the below issue:


Wrong reads were found when multiple lanes are present

E.g:
    - data:
        lane: 7
        percent_q30: 83.2435073852539
        read: 14
        threshold: 85
      message: '%Q30 83.24 was too low on lane: 7 for read: 14'
      type: warningFYI: I've found a bug in CheckQC that needs to be solved asap. Me and 


