### PR TITLE
Fix reads per samples

### DIFF
--- a/checkQC/qc_checkers/reads_per_sample.py
+++ b/checkQC/qc_checkers/reads_per_sample.py
@@ -54,6 +54,6 @@ def reads_per_sample(
                 len(lane_data["reads_per_sample"]),
                 sample_data["sample_id"],
                 sample_data["cluster_count"],
-            ),
+            )
         )
     ]

--- a/tests/qc_checkers/test_cluster_pf.py
+++ b/tests/qc_checkers/test_cluster_pf.py
@@ -28,6 +28,7 @@ def test_cluster_pf(qc_data):
     )
 
     assert len(qc_reports) == 2
+    assert None not in qc_reports
     for report in qc_reports:
         lane, threshold = report.data["lane"], report.data["threshold"]
         match lane:
@@ -60,6 +61,7 @@ def test_cluster_pf_error_unknown(qc_data):
     )
 
     assert len(qc_reports) == 2
+    assert None not in qc_reports
     for report in qc_reports:
         lane, threshold = report.data["lane"], report.data["threshold"]
         match lane:
@@ -92,6 +94,7 @@ def test_cluster_pf_warning_unknown(qc_data):
     )
 
     assert len(qc_reports) == 1
+    assert None not in qc_reports
     report = qc_reports[0]
     lane, threshold = report.data["lane"], report.data["threshold"]
     match lane:

--- a/tests/qc_checkers/test_error_rate.py
+++ b/tests/qc_checkers/test_error_rate.py
@@ -72,6 +72,7 @@ def test_error_rate(qc_data_and_exp_val):
     )
 
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]
@@ -92,6 +93,7 @@ def test_error_rate_error_unknown(qc_data_and_exp_val):
     del exp_val[2][1]
 
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]
@@ -117,6 +119,7 @@ def test_error_rate_warning_unknown(qc_data_and_exp_val):
     del exp_val[2][1]
 
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]
@@ -140,6 +143,7 @@ def test_error_rate_allow_missing(qc_data_and_exp_val):
     del exp_val[1][3]
 
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]

--- a/tests/qc_checkers/test_percent_q30.py
+++ b/tests/qc_checkers/test_percent_q30.py
@@ -65,6 +65,7 @@ def test_percent_q30(qc_data_and_exp_val):
     )
 
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]
@@ -92,6 +93,7 @@ def test_error_rate_error_unknown(qc_data_and_exp_val):
                 )
 
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]
@@ -118,6 +120,7 @@ def test_error_rate_warning_unknown(qc_data_and_exp_val):
     del exp_val[2][4]
     
     assert len(qc_reports) == sum(len(v) for v in exp_val.values())
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane, read = qc_report.data['lane'], qc_report.data['read']
         expected_report = exp_val[lane][read]

--- a/tests/qc_checkers/test_reads_per_sample.py
+++ b/tests/qc_checkers/test_reads_per_sample.py
@@ -98,9 +98,8 @@ def test_reads_per_sample_unknown_threshold(qc_data_and_exp_val):
             "lane": 1,
             "number_of_samples": 2,
             "sample_id": "Sample_B",
-            "sample_reads": 20,
-            "threshold": 30,
-            "qc_checker": "reads_per_sample",
+            "sample_reads": 20.,
+            "threshold": 30.,
         }
     )
     assert qc_reports[0].type() == expected_report.type()

--- a/tests/qc_checkers/test_reads_per_sample.py
+++ b/tests/qc_checkers/test_reads_per_sample.py
@@ -70,6 +70,7 @@ def test_reads_per_sample(qc_data_and_exp_val):
     )
 
     assert len(qc_reports) == 2
+    assert None not in qc_reports
     for qc_report in qc_reports:
         lane = qc_report.data['lane']
         expected_report = exp_val[lane]
@@ -89,6 +90,7 @@ def test_reads_per_sample_unknown_threshold(qc_data_and_exp_val):
     )
 
     assert len(qc_reports) == 2
+    assert None not in qc_reports
     expected_report = QCErrorWarning(
         "Number of reads for sample Sample_B on lane 1 were too low:"
         " 20.0 M (threshold: 30.0 M)",

--- a/tests/qc_checkers/test_reads_per_sample.py
+++ b/tests/qc_checkers/test_reads_per_sample.py
@@ -69,8 +69,8 @@ def test_reads_per_sample(qc_data_and_exp_val):
         warning_threshold=60,
     )
 
-    assert len(qc_reports) == 4
-    for qc_report in filter(None, qc_reports):
+    assert len(qc_reports) == 2
+    for qc_report in qc_reports:
         lane = qc_report.data['lane']
         expected_report = exp_val[lane]
 
@@ -88,15 +88,20 @@ def test_reads_per_sample_unknown_threshold(qc_data_and_exp_val):
         warning_threshold=60,
     )
 
-    assert len(qc_reports) == 4
+    assert len(qc_reports) == 2
     expected_report = QCErrorWarning(
-                "Number of reads for sample Sample_B on lane 1 were too low:"
-                " 20.0 M (threshold: 30.0 M)",
-                data={"lane": 1,
-                      "number_of_samples": 2,
-                      "sample_id": "Sample_B",
-                      "sample_reads": 20,
-                      "threshold": 30}
-                )
-    assert qc_reports[1].type() == expected_report.type()
-    assert qc_reports[1].data == expected_report.data
+        "Number of reads for sample Sample_B on lane 1 were too low:"
+        " 20.0 M (threshold: 30.0 M)",
+        data={
+            "lane": 1,
+            "number_of_samples": 2,
+            "sample_id": "Sample_B",
+            "sample_reads": 20,
+            "threshold": 30,
+            "qc_checker": "reads_per_sample",
+        }
+    )
+    assert qc_reports[0].type() == expected_report.type()
+    assert qc_reports[0].data == expected_report.data
+
+    assert qc_reports[1].type() == "warning"

--- a/tests/qc_checkers/test_undetermined_percentage.py
+++ b/tests/qc_checkers/test_undetermined_percentage.py
@@ -29,6 +29,7 @@ def test_error_threshold():
     )
 
     assert len(qc_reports) == 1
+    assert None not in qc_reports
     assert qc_reports[0].type() == "error"
     assert str(qc_reports[0]) == "Fatal QC error: Percentage of undetermined indices 20.00% (- 1.00% phiX) > 15.00% on lane 1."
     assert qc_reports[0].data == {
@@ -60,6 +61,7 @@ def test_warning_threshold():
     )
 
     assert len(qc_reports) == 1
+    assert None not in qc_reports
     assert qc_reports[0].type() == "warning"
     assert str(qc_reports[0]) == "QC warning: Percentage of undetermined indices 20.00% (- 1.00% phiX) > 5.00% on lane 1."
     assert qc_reports[0].data == {
@@ -130,6 +132,7 @@ def test_multiple_reports():
     )
 
     assert len(qc_reports) == 2
+    assert None not in qc_reports
     for report in qc_reports:
         match report.data["lane"]:
             case 1:
@@ -175,6 +178,7 @@ def test_yield_0():
     )
 
     assert len(qc_reports) == 1
+    assert None not in qc_reports
     assert qc_reports[0].type() == "error"
     assert str(qc_reports[0]) == "Fatal QC error: Yield for lane 1 was 0. No undetermined percentage could be computed"
     assert qc_reports[0].data == {"lane": 1, "percentage_undetermined": None}
@@ -201,6 +205,7 @@ def test_mean_percent_phix_nan():
     )
 
     assert len(qc_reports) == 1
+    assert None not in qc_reports
     assert qc_reports[0].type() == "error"
     assert str(qc_reports[0]) == "Fatal QC error: Percentage of undetermined indices 20.00% (- 1.00% phiX) > 15.00% on lane 3."
     assert qc_reports[0].data == {

--- a/tests/qc_checkers/test_unidentified_index.py
+++ b/tests/qc_checkers/test_unidentified_index.py
@@ -183,6 +183,7 @@ def test_unidentified_index(qc_data):
     reports = unidentified_index(qc_data, 5.)
 
     assert len(reports) == 2
+    assert None not in reports
     assert str(reports[0]) == """Fatal QC error: Overrepresented unknown barcode "ACCT" on lane 1 (10.0% > 5.0%).
 Possible causes are:
 - reverse index swap: "TCCA" found in samplesheet for sample "reverse", lane 1
@@ -197,6 +198,7 @@ def test_whitelist_index(qc_data):
             qc_data, 5.,
             white_listed_indexes=[".*CC.*"])
     assert len(reports) == 2
+    assert None not in reports
     assert str(reports[0]).startswith(
         "QC warning: Overrepresented unknown barcode \"ACCT\" on lane 1 (10.0% > 5.0%). "
         "This barcode is white-listed."


### PR DESCRIPTION
A subtle bug found its way in the reads per sample checker: because of this extra comma on line 57, `qc_report` was packed into a tuple and the `if`-statement sometimes looked like `if (None,)`, which surprisingly enough always return `True`.

This PR removes this rogue comma and adds assertions to make sure qc_checkers always return valid reports.